### PR TITLE
Update wsfedsaml.js as previously it was throwing an error and would not allow login.

### DIFF
--- a/lib/passport-azure-ad/wsfedsaml.js
+++ b/lib/passport-azure-ad/wsfedsaml.js
@@ -61,7 +61,7 @@ Object.defineProperty(SAML, 'certs', {
 SAML.prototype.validateSignature = function (xml, cert, thumbprint) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath.SelectNodes(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xmlCrypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new xmlCrypto.SignedXml(null, { idAttribute: 'AssertionID' });
   sig.keyInfoProvider = {
     getKeyInfo: function () {


### PR DESCRIPTION
The 'xpath' function appears to be an alias for SelectNodes, so you can't call 'SelectNodes.SelectNodes'

in the documentation for xml-crypto, 'xpath' is used instead of 'SelectNodes', so making this match.
