### PR TITLE
Added wsa prefix support in metadata document

### DIFF
--- a/lib/passport-azure-ad/aadutils.js
+++ b/lib/passport-azure-ad/aadutils.js
@@ -24,6 +24,8 @@ exports.getElement = function (parentElement, elementName) {
     return parentElement['saml:' + elementName];
   } else if (parentElement['samlp:'+elementName]) {
     return parentElement['samlp:'+elementName];
+  } else if (parentElement['wsa:' + elementName]) {
+    return parentElement['wsa:' + elementName];
   }
   return parentElement[elementName];
 };
@@ -36,11 +38,10 @@ exports.getFirstElement = function (parentElement, elementName) {
     element =  parentElement['saml:' + elementName];
   } else if (parentElement['samlp:'+elementName]) {
     element =  parentElement['samlp:'+elementName];
+  } else if (parentElement['wsa:' + elementName]) {
+    element =  parentElement['wsa:' + elementName];
   } else {
     element = parentElement[elementName];
   }
   return Array.isArray(element) ? element[0] : element;
 };
-
-
-


### PR DESCRIPTION
Adding support for was elements inside of a ADFS metadata document.  I'm not 100% sure this is all that is needed but it worked for my use case.
