### PR TITLE
Warn users about peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,31 +17,25 @@ For a detailed walkthrough of using Passport.js to add web single sign-on to a N
 $ npm install passport-azure-ad
 ```
 
-## Dependencies
-
-**Important:** make sure you add the following middleware modules to your application stack:
-
-- [cookie-parser](https://github.com/expressjs/cookie-parser)
-- [body-parser](https://github.com/expressjs/body-parser)
-- [express-session](https://github.com/expressjs/session)
-
 ## Usage
 
 This sample uses a WS-Federation protocol with express:
 
 ```javascript
 var express = require('express');
+var cookieParser = require('cookie-parser');
+var expressSession = require('express-session');
+var bodyParser = require('body-parser');
 var passport = require('passport');
 var wsfedsaml2 = require('passport-azure-ad').WsfedStrategy
 var app = express();
 
 // configure express
-app.use(express.cookieParser());
-app.use(express.bodyParser());
-app.use(express.session({ secret: 'keyboard cat' }));
+app.use(cookieParser());
+app.use(expressSession({ secret: 'keyboard cat', resave: true, saveUninitialized: false }));
+app.use(bodyParser.urlencoded({ extended : true }));
 app.use(passport.initialize());
 app.use(passport.session());
-app.use(app.router);
 
 var config = {
 	realm: 'http://localhost:3000/',
@@ -75,7 +69,7 @@ app.post('/login/callback', passport.authenticate('wsfed-saml2', { failureRedire
     res.redirect('/');
 });
 
-app.listen(process.env.PORT || 3000)
+app.listen(process.env.PORT || 3000);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ For a detailed walkthrough of using Passport.js to add web single sign-on to a N
 $ npm install passport-azure-ad
 ```
 
+## Dependencies
+
+**Important:** make sure you add the following middleware modules to your application stack:
+
+- [cookie-parser](https://github.com/expressjs/cookie-parser)
+- [body-parser](https://github.com/expressjs/body-parser)
+- [express-session](https://github.com/expressjs/session)
+
 ## Usage
 
 This sample uses a WS-Federation protocol with express:

--- a/examples/login-saml/app.js
+++ b/examples/login-saml/app.js
@@ -21,6 +21,9 @@
  * Module dependencies.
  */
 var express = require('express');
+var cookieParser = require('cookie-parser');
+var expressSession = require('express-session');
+var bodyParser = require('body-parser');
 var passport = require('passport');
 var http = require('http');
 var SamlStrategy = require('../../lib/passport-azure-ad/index').SamlStrategy;
@@ -98,13 +101,12 @@ app.configure(function() {
   app.set('view engine', 'ejs');
   app.use(express.favicon());
   app.use(express.logger('dev'));
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
+  app.use(cookieParser());
+  app.use(expressSession({ secret: 'keyboard cat', resave: true, saveUninitialized: false }));
+  app.use(bodyParser.urlencoded({ extended : true }));
   app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
   app.use(passport.initialize());
   app.use(passport.session());
-  app.use(app.router);
   app.use(express.static(PATH.join(__dirname, 'public')));
 });
 

--- a/examples/login-wsfed/app.js
+++ b/examples/login-wsfed/app.js
@@ -21,6 +21,9 @@
  * Module dependencies.
  */
 var express = require('express');
+var cookieParser = require('cookie-parser');
+var expressSession = require('express-session');
+var bodyParser = require('body-parser');
 var http = require('http');
 var path = require('path');
 var passport = require('passport');
@@ -64,13 +67,12 @@ app.configure(function(){
   app.set('view engine', 'ejs');
   app.use(express.favicon());
   app.use(express.logger('dev'));
-  app.use(express.bodyParser());
   app.use(express.methodOverride());
-  app.use(express.cookieParser('your secret here'));
-  app.use(express.session({ secret: 'keyboard cat' }));
+  app.use(cookieParser());
+  app.use(expressSession({ secret: 'keyboard cat', resave: true, saveUninitialized: false }));
+  app.use(bodyParser.urlencoded({ extended : true }));
   app.use(passport.initialize());
   app.use(passport.session());
-  app.use(app.router);
   app.use(express.static(path.join(__dirname, 'public')));
 });
 

--- a/package.json
+++ b/package.json
@@ -29,14 +29,19 @@
   },
   "main": "./lib/passport-azure-ad",
   "dependencies": {
-    "passport": "0.1.x",
-    "xml2js": "0.2.6",
-    "xml-crypto": "0.0.x",
-    "xmldom": "0.1.x",
     "async": "~0.2.7",
+    "passport": "0.1.x",
     "request": "~2.16.6",
     "underscore": "~1.4.4",
+    "xml-crypto": "0.0.x",
+    "xml2js": "0.2.6",
+    "xmldom": "0.1.x",
     "xtend": "~2.0.3"
+  },
+  "peerDependencies": {
+    "body-parser": "^1.12.3",
+    "cookie-parser": "^1.3.4",
+    "express-session": "^1.11.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
It took me a while to find out that [expressjs/express-session](https://github.com/expressjs/express-session), [expressjs/cookie-parser](https://github.com/expressjs/body-parser) and [expressjs/body-parser](https://github.com/expressjs/body-parser) are required by this middleware. It's very hard to detect this, there's no error message at all.