### PR TITLE
return the callback for federationmetadata template on consecutive reque...

### DIFF
--- a/lib/passport-azure-ad/saml.js
+++ b/lib/passport-azure-ad/saml.js
@@ -108,6 +108,8 @@ SAML.prototype.identity = function (callback) {
       }
       callback(err, data);
     });
+  } else {
+   callback(null, this.federationMetadata);
   }
 };
 


### PR DESCRIPTION
...sts (fixes #22)

Fixes an issue that the callback is never called on a second render of the federation metadata because, it does not match the condition anymore `this.federationMetadata === null` - it would happen when you viewed the `/identity` route twice for example. The page would just never respond.