### PR TITLE
OpenID Connect POST fix, Support for v1 or v2 of our API, more.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Microsoft Open Technologies, Inc.
+Copyright (c) Microsoft.
   All Rights Reserved
   Apache License 2.0
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
 
 passport-azure-ad is a collection of [Passport](http://passportjs.org/) Strategies to help you integrate with Azure Active Ditectory. It includes OpenID Connect, WS-Federation, and SAML-P authentication and authorization. These providers let you integrate your Node app with Microsoft Azure AD so you can use its many features, including web single sign-on (WebSSO), Endpoint Protection with OAuth, and JWT token issuance and validation.
 
-
-The code is based on Henri Bergius's [passport-saml](https://github.com/bergie/passport-saml) library and Matias Woloski's [passport-wsfed-saml2](https://github.com/auth0/passport-wsfed-saml2) library as well as Kiyofumi Kondoh's [passport-openid-google](https://github.com/kkkon/passport-google-openidconnect).
-
 passport-azure-ad has been tested to work with both [Windows Azure Active Directory](https://www.windowsazure.com/en-us/home/features/identity/) and with [Microsoft Active Directory Federation Services](http://en.wikipedia.org/wiki/Active_Directory_Federation_Services).
-
-For a detailed walkthrough of using Passport.js to add web single sign-on to a Node app, see: [Windows Azure AD Walkthrough for Node.js](https://github.com/MSOpenTech/AzureAD-Node-Sample/wiki).
 
 
 ## Installation
@@ -57,31 +52,31 @@ var bearerStrategy = new BearerStrategy(options,
 This sample uses the OIDCStrategy:
 
 ```javascript
-// Use the OIDCStrategy within Passport.
-//   Strategies in passport require a `validate` function, which accept
-//   credentials (in this case, an OpenID identifier), and invoke a callback
-//   with a user object.
 passport.use(new OIDCStrategy({
     callbackURL: config.creds.returnURL,
     realm: config.creds.realm,
     clientID: config.creds.clientID,
     clientSecret: config.creds.clientSecret,
     oidcIssuer: config.creds.issuer,
-    identityMetadata: config.creds.identityMetadata
+    identityMetadata: config.creds.identityMetadata,
+    responseType: config.creds.responseType,
+    responseMode: config.creds.responseMode,
+    skipUserProfile: config.creds.skipUserProfile
+    scope: config.creds.scope
   },
-  function(iss, sub, profile, accessToken, refreshToken, done) {
-    log.info('We received profile of: ', profile);
-    log.info('Example: Email address we received was: ', profile._json.upn);
+  function(iss, sub, profile, claims, accessToken, refreshToken, params, done) {
+    log.info('We received claims of: ', claims);
+    log.info('Example: Email address we received was: ', claims.preferred_username || claims.upn);
     // asynchronous verification, for effect...
     process.nextTick(function () {
-      findByEmail(profile._json.upn, function(err, user) {
+      findByEmail(claims.preferred_username, function(err, user) {
         if (err) {
           return done(err);
         }
         if (!user) {
           // "Auto-registration"
-          users.push(profile);
-          return done(null, profile);
+          users.push(claims);
+          return done(null, claims);
         }
         return done(null, user);
       });
@@ -102,41 +97,30 @@ app.get('/login',
     res.redirect('/');
 });
 
-// POST /auth/openid
-//   Use passport.authenticate() as route middleware to authenticate the
-//   request.  The first step in OpenID authentication will involve redirecting
-//   the user to their OpenID provider.  After authenticating, the OpenID
-//   provider will redirect the user back to this application at
-//   /auth/openid/return
-
-
-app.post('/auth/openid', 
-  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
-  function(req, res) {
-    log.info('Authenitcation was called in the Sample');
-    res.redirect('/');
-  });
-
-// GET /auth/openid/return
+// POST /auth/openid/return
 //   Use passport.authenticate() as route middleware to authenticate the
 //   request.  If authentication fails, the user will be redirected back to the
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
-
-app.get('/auth/openid/return', 
+app.post('/auth/openid/return',
   passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
   function(req, res) {
-    log.info('We received a return from AzureAD.');
-    res.redirect('/');
     
+    res.redirect('/');
   });
+
+  app.get('/logout', function(req, res){
+  req.logout();
+  res.redirect('/');
+});
+
 ```
 
 ## Samples and Documentation
 
 [We provide a full suite of sample applications and documentation on GitHub](https://github.com/AzureADSamples) to help you get started with learning the Azure Identity system. This includes tutorials for native clients such as Windows, Windows Phone, iOS, OSX, Android, and Linux. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect, Graph API, and other awesome features. 
 
-Azure Identity samples for this plug-in is here: [https://github.com/AzureADSamples/WebAPI-Nodejs](https://github.com/AzureADSamples/WebAPI-Nodejs)
+Azure Identity samples for this plug-in is here: [https://github.com/AzureADSamples/WebApp-OpenIdConnect-nodejs](https://github.com/AzureADSamples/WebApp-OpenIdConnect-nodejs)
 
 
 ## Community Help and Support
@@ -153,6 +137,10 @@ More details [about contribution](https://github.com/AzureAD/passport-azure-ad/b
 
 ## Versions
 Please check the releases for updates.
+
+## Acknowledgements
+
+The code is based on Henri Bergius's [passport-saml](https://github.com/bergie/passport-saml) library and Matias Woloski's [passport-wsfed-saml2](https://github.com/auth0/passport-wsfed-saml2) library as well as Kiyofumi Kondoh's [passport-openid-google](https://github.com/kkkon/passport-google-openidconnect).
 
 ## License
 Copyright (c) Microsoft Corp.  All rights reserved. Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/login-oidc/README.md
+++ b/examples/login-oidc/README.md
@@ -1,6 +1,6 @@
 # SAML SSO Example  for Azure Active Directory
 
-[Passport](http://passportjs.org/) strategy for authenticating with Windows Azure Active Directory using SAML. 
+[Passport](http://passportjs.org/) strategy for authenticating with Azure Active Directory using OIDC. 
 
 ## Install
 
@@ -13,4 +13,4 @@ node app
 
 
 ## License
-Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved. Licensed under the Apache License, Version 2.0 (the "License"); 
+Copyright (c) Microsoft.  All rights reserved. Licensed under the MIT License. 

--- a/examples/login-oidc/app.js
+++ b/examples/login-oidc/app.js
@@ -148,18 +148,6 @@ app.get('/login',
 
 // Our POST routes (Section 3)
 
-// POST /auth/openid
-//   Use passport.authenticate() as route middleware to authenticate the
-//   request.  The first step in OpenID authentication will involve redirecting
-//   the user to their OpenID provider.  After authenticating, the OpenID
-//   provider will redirect the user back to this application at
-//   /auth/openid/return
-app.post('/auth/openid',
-  passport.authenticate('azuread-openidconnect', { FailureRedirect: '/login' }),
-  function(req, res) {
-    log.info('Authenitcation was called in the Sample');
-    res.redirect('/');
-  });
 
 // GET /auth/openid/return
 //   Use passport.authenticate() as route middleware to authenticate the

--- a/examples/login-oidc/app.js
+++ b/examples/login-oidc/app.js
@@ -30,21 +30,25 @@ var bodyParser = require('body-parser');
 var passport = require('passport');
 var util = require('util');
 var bunyan = require('bunyan');
-var config = require('./client_config');
-var OIDCStrategy = require('../../lib/passport-azure-ad/index').OIDCStrategy;
+var config = require('./config');
+
+// Start QuickStart here
+
+var OIDCStrategy = require('./lib/passport-azure-ad/index').OIDCStrategy;
 
 var log = bunyan.createLogger({
     name: 'Microsoft OIDC Example Web Application'
 });
 
 
-// Passport session setup.
+// Passport session setup. (Section 2)
+
 //   To support persistent login sessions, Passport needs to be able to
 //   serialize users into and deserialize users out of the session.  Typically,
 //   this will be as simple as storing the user ID when serializing, and finding
 //   the user by ID when deserializing.
 passport.serializeUser(function(user, done) {
-  done(null, user._json.upn);
+  done(null, user.preferred_username || user.upn);
 });
 
 passport.deserializeUser(function(id, done) {
@@ -59,14 +63,15 @@ var users = [];
 var findByEmail = function(email, fn) {
   for (var i = 0, len = users.length; i < len; i++) {
     var user = users[i];
-    if (user._json.upn === email) {
+    if (user.preferred_username || user.upn === email) {
       return fn(null, user);
     }
   }
   return fn(null, null);
 };
 
-// Use the OIDCStrategy within Passport.
+// Use the OIDCStrategy within Passport. (Section 2) 
+// 
 //   Strategies in passport require a `validate` function, which accept
 //   credentials (in this case, an OpenID identifier), and invoke a callback
 //   with a user object.
@@ -76,21 +81,25 @@ passport.use(new OIDCStrategy({
     clientID: config.creds.clientID,
     clientSecret: config.creds.clientSecret,
     oidcIssuer: config.creds.issuer,
-    identityMetadata: config.creds.identityMetadata
+    identityMetadata: config.creds.identityMetadata,
+    responseType: config.creds.responseType,
+    responseMode: config.creds.responseMode,
+    skipUserProfile: config.creds.skipUserProfile
+    //scope: config.creds.scope
   },
-  function(iss, sub, profile, accessToken, refreshToken, done) {
-    log.info('We received profile of: ', profile);
-    log.info('Example: Email address we received was: ', profile._json.upn);
+  function(iss, sub, profile, claims, accessToken, refreshToken, params, done) {
+    log.info('We received claims of: ', claims);
+    log.info('Example: Email address we received was: ', claims.preferred_username || claims.upn);
     // asynchronous verification, for effect...
     process.nextTick(function () {
-      findByEmail(profile._json.upn, function(err, user) {
+      findByEmail(claims.preferred_username, function(err, user) {
         if (err) {
           return done(err);
         }
         if (!user) {
           // "Auto-registration"
-          users.push(profile);
-          return done(null, profile);
+          users.push(claims);
+          return done(null, claims);
         }
         return done(null, user);
       });
@@ -99,25 +108,28 @@ passport.use(new OIDCStrategy({
 ));
 
 
-
+// configure Express (Section 2)
 
 var app = express();
 
-// configure Express
+
 app.configure(function() {
   app.set('views', __dirname + '/views');
   app.set('view engine', 'ejs');
   app.use(express.logger());
+  app.use(express.methodOverride());
   app.use(cookieParser());
   app.use(expressSession({ secret: 'keyboard cat', resave: true, saveUninitialized: false }));
   app.use(bodyParser.urlencoded({ extended : true }));
-  app.use(express.methodOverride());
+  // Initialize Passport!  Also use passport.session() middleware, to support
+  // persistent login sessions (recommended).
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(app.router);
   app.use(express.static(__dirname + '/../../public'));
 });
 
+//Routes (Section 4)
 
 app.get('/', function(req, res){
   res.render('index', { user: req.user });
@@ -127,12 +139,14 @@ app.get('/account', ensureAuthenticated, function(req, res){
   res.render('account', { user: req.user });
 });
 
-app.get('/login', 
+app.get('/login',
   passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
   function(req, res) {
     log.info('Login was called in the Sample');
     res.redirect('/');
 });
+
+// Our POST routes (Section 3)
 
 // POST /auth/openid
 //   Use passport.authenticate() as route middleware to authenticate the
@@ -140,8 +154,8 @@ app.get('/login',
 //   the user to their OpenID provider.  After authenticating, the OpenID
 //   provider will redirect the user back to this application at
 //   /auth/openid/return
-app.post('/auth/openid', 
-  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+app.post('/auth/openid',
+  passport.authenticate('azuread-openidconnect', { FailureRedirect: '/login' }),
   function(req, res) {
     log.info('Authenitcation was called in the Sample');
     res.redirect('/');
@@ -152,10 +166,22 @@ app.post('/auth/openid',
 //   request.  If authentication fails, the user will be redirected back to the
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
-app.get('/auth/openid/return', 
+app.get('/auth/openid/return',
   passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
   function(req, res) {
-    log.info('We received a return from AzureAD.');
+    
+    res.redirect('/');
+  });
+
+// POST /auth/openid/return
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function function will be called,
+//   which, in this example, will redirect the user to the home page.
+app.post('/auth/openid/return',
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+  function(req, res) {
+    
     res.redirect('/');
   });
 
@@ -167,7 +193,8 @@ app.get('/logout', function(req, res){
 app.listen(3000);
 
 
-// Simple route middleware to ensure user is authenticated.
+// Simple route middleware to ensure user is authenticated. (Section 4)
+
 //   Use this route middleware on any resource that needs to be protected.  If
 //   the request is authenticated (typically via a persistent login session),
 //   the request will proceed.  Otherwise, the user will be redirected to the

--- a/examples/login-oidc/client_config.js
+++ b/examples/login-oidc/client_config.js
@@ -3,11 +3,9 @@
  exports.creds = {
  	returnURL: 'http://localhost:3000/auth/openid/return',
  	identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
- 	realm: 'http://localhost:3000',
- 	clientID: '6450da98-4793-4dbd-9945-56a26737e229',
- 	clientSecret: 'vPSgl3vyVR8w8Ge/A8hYbhIm8eZEcAmC4JCIB5jeoI8=',
- 	skipUserProfile: true, // for OpenID only flows this should be set to true
- 	responseType: 'id_token code', // for login only flows
- 	responseMode: 'form_post', // As per the OAuth 2.0 standard.
+ 	clientID: '<your application ID>',
+ 	clientSecret: '<your client secret>', // if you are doing code or id_token code
+ 	skipUserProfile: true, // for AzureAD should be set to true.
+ 	responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
+ 	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
- };

--- a/examples/login-oidc/client_config.js
+++ b/examples/login-oidc/client_config.js
@@ -4,7 +4,10 @@
  	returnURL: 'http://localhost:3000/auth/openid/return',
  	identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
  	realm: 'http://localhost:3000',
- 	issuer: 'https://sts.windows.net/cff56d8f-f602-4afd-94e4-c95b76f1c81e/',
- 	clientID: 'c9655d1d-f356-46a7-afe1-431c0d6eeb37',
- 	clientSecret: 'jRXwIofdH7Hju2V1E1ab5v5uLVf68mhVgEeIRaBMXf0='
+ 	clientID: '6450da98-4793-4dbd-9945-56a26737e229',
+ 	clientSecret: 'vPSgl3vyVR8w8Ge/A8hYbhIm8eZEcAmC4JCIB5jeoI8=',
+ 	skipUserProfile: true, // for OpenID only flows this should be set to true
+ 	responseType: 'id_token code', // for login only flows
+ 	responseMode: 'form_post', // As per the OAuth 2.0 standard.
+ 	//scope: ['email', 'profile'] // additional scopes you may wish to pass
  };

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -53,24 +53,26 @@ function Strategy(options, verify) {
 
     });
 
-  
+
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  
+  this._responseType = options.responseType || 'code id_token';
+  this._responseMode = options.responseMode || 'form_post';
+
   this._configurers = [];
-  
+
   // https://login.microsoftonline.com/common/.well-known/openid-configuration
-  // NOTE: We will always use the values returned from the metadata endpoint. If they conflict with the configuration below the 
+  // NOTE: We will always use the values returned from the metadata endpoint. If they conflict with the configuration below the
   // values from the metadata endpoint will be used instead.
-  // 
+  //
   options.authorizationURL = options.authorizationURL || 'https://login.microsoftonline.com/common/oauth2/authorize';
   options.tokenURL = options.tokenURL || 'https://login.microsoftonline.com/common/oauth2/token';
-  options.userInfoURL = options.userInfoURL || 'https://login.microsoftonline.com/common/openid/userinfo';
-  options.revocationURL = options.revocationURL || 'https://login.microsoftonline.com/common/oauth2/logout';
+  options.userInfoURL = options.userInfoURL || 'https://login.microsoftonline.com/common/oauth2/userinfo';
+  options.revocationURL = options.revocationURL || 'https://login.microsoftonline.com/oauth2/oauth2/logout';
   options.tokenInfoURL = options.tokenInfoURL || null;
   options.oidcIssuer = options.oidcIssuer || 'https://sts.windows.net/{tenantid}/';
 
@@ -109,23 +111,36 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
+  log.info('Query received was: ', req.query);
+
   if (req.query && req.query.error) {
+
+    log.info("OPENID CONNECT ERROR: We are in the OpenID Connect Response with error. Assumed because no auth code was in the query.")
+        log.info("");
+        log.info('ERror received was: ', req.query.error);
+
+
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
-  
-  if (req.query && req.query.code) {
-    var code = req.query.code;
+
+
+  else if (req.query && req.query.code || req.method === 'POST' && req.body['code']) {
     
+
+    if (req.query) { var code = req.query.code; }
+    if (req.body['code']) { var code = req.body['code']; }
+
+    log.info("OAUTH2: Got access code: ", code);
+
     this.configure(null, function(err, config) {
       if (err) { return self.error(err); }
-    
+
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
                               '', config.authorizationURL, config.tokenURL);
-                              
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -135,10 +150,10 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
-        
+
         log.info('TOKEN RECEIVED');
         log.info('Access Token: ' + accessToken);
         log.info('');
@@ -146,23 +161,23 @@ Strategy.prototype.authenticate = function(req, options) {
         log.info('');
         log.info(params);
         log.info('----');
-        
+
         var idToken = params['id_token'];
         if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
-        
+
         var idTokenSegments = idToken.split('.')
           , jwtClaimsStr
           , jwtClaims;
-        
+
         try {
           jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
           jwtClaims = JSON.parse(jwtClaimsStr);
         } catch (ex) {
           return self.error(ex);
         }
-        
+
         log.info('Claimes received: ', jwtClaims);
-        
+
         var iss = jwtClaims.iss;
         var sub = jwtClaims.sub;
         // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
@@ -171,20 +186,20 @@ Strategy.prototype.authenticate = function(req, options) {
         if (!sub) {
           sub = jwtClaims.user_id;
         }
-        
+
         // TODO: Ensure claims are validated per:
         //       http://openid.net/specs/openid-connect-basic-1_0.html#id_token
-        
-        
+
+
         self._shouldLoadUserProfile(iss, sub, function(err, load) {
           if (err) { return self.error(err); };
-          
+
           if (load) {
             var parsed = url.parse(config.userInfoURL, true);
             parsed.query['schema'] = 'openid';
             delete parsed.search;
             var userInfoURL = url.format(parsed);
-            
+
             // NOTE: We are calling node-oauth's internal `_request` function (as
             //       opposed to `get`) in order to send the access token in the
             //       `Authorization` header rather than as a query parameter.
@@ -195,20 +210,20 @@ Strategy.prototype.authenticate = function(req, options) {
             //       Setting the fifth argument of `_request` to `null` works
             //       around this issue.  I've noted this in comments here:
             //       https://github.com/ciaranj/node-oauth/issues/117
-            
+
             //oauth2.get(userInfoURL, accessToken, function (err, body, res) {
             oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
               if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
-              
+
               log.info('PROFILE LOADED FROM MS IDENTITY');
               log.info(body);
               log.info('-------');
-              
+
               var profile = {};
-              
+
               try {
                 var json = JSON.parse(body);
-                
+
                 profile.id = json.sub;
                 // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
                 // "sub" key was named "user_id".  Many providers still use the old
@@ -216,15 +231,15 @@ Strategy.prototype.authenticate = function(req, options) {
                 if (!profile.id) {
                   profile.id = json.user_id;
                 }
-                
+
                 profile.displayName = json.name;
                 profile.name = { familyName: json.family_name,
                                  givenName: json.given_name,
                                  middleName: json.middle_name };
-                
+
                 profile._raw = body;
                 profile._json = json;
-                
+
                 onProfileLoaded(profile);
               } catch(ex) {
                 return self.error(ex);
@@ -233,14 +248,14 @@ Strategy.prototype.authenticate = function(req, options) {
           } else {
             onProfileLoaded();
           }
-          
+
           function onProfileLoaded(profile) {
             function verified(err, user, info) {
               if (err) { return self.error(err); }
               if (!user) { return self.fail(info); }
               self.success(user, info);
             }
-          
+
             if (self._passReqToCallback) {
               var arity = self._verify.length;
               if (arity == 9) {
@@ -269,27 +284,128 @@ Strategy.prototype.authenticate = function(req, options) {
               }
             }
           }
-          
+
         });
       });
     });
-  } else {
+  } else if (req.body && req.method === 'POST') {
+
+        log.info("OPENID CONNECT: We are in the OpenID Connect Only Response. Assumed because no auth code was in the query and we are POST.")
+        log.info("");
+        log.info('Body received was: ', req.body);
+
+        //We are not doing auth code so we set the tokens to null
+        //
+        
+        var accessToken = null;
+        var refreshToken = null;
+        var params = null;
+
+        // We have a response, get the user identity out of it
+        // 
+        var idToken = req.body['id_token'];
+        if (!idToken) { return self.error(new Error('ID Token not present in response')); }
+
+        var idTokenSegments = idToken.split('.')
+          , jwtClaimsStr
+          , jwtClaims;
+
+        try {
+          jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
+          jwtClaims = JSON.parse(jwtClaimsStr);
+        } catch (ex) {
+          return self.error(ex);
+        }
+
+        log.info('Claimes received: ', jwtClaims);
+
+        var iss = jwtClaims.iss;
+        var sub = jwtClaims.sub;
+        // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
+        // "sub" claim was named "user_id".  Many providers still issue the
+        // claim under the old field, so fallback to that.
+        if (!sub) {
+          sub = jwtClaims.user_id;
+        }
+
+        var profile = {};
+
+              try {
+
+                profile.id = jwtClaims.sub;
+                // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
+                // "sub" key was named "user_id".  Many providers still use the old
+                // key, so fallback to that.
+                if (!profile.id) {
+                  profile.id = jwtClaims.user_id;
+                }
+
+                profile._raw = req.body;
+                profile._json = idToken;
+
+                onProfileLoaded(profile);
+              } catch(ex) {
+                return self.error(ex);
+              }
+
+              function onProfileLoaded(profile) {
+            function verified(err, user, info) {
+              if (err) { return self.error(err); }
+              if (!user) { return self.fail(info); }
+              self.success(user, info);
+            }
+
+            if (self._passReqToCallback) {
+              var arity = self._verify.length;
+              if (arity == 9) {
+                self._verify(req, iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
+              } else if (arity == 8) {
+                self._verify(req, iss, sub, profile, accessToken, refreshToken, params, verified);
+              } else if (arity == 7) {
+                self._verify(req, iss, sub, profile, accessToken, refreshToken, verified);
+              } else if (arity == 5) {
+                self._verify(req, iss, sub, profile, verified);
+              } else { // arity == 4
+                self._verify(req, iss, sub, verified);
+              }
+            } else {
+              var arity = self._verify.length;
+              if (arity == 8) {
+                self._verify(iss, sub, profile, jwtClaims, accessToken, refreshToken, params, verified);
+              } else if (arity == 7) {
+                self._verify(iss, sub, profile, accessToken, refreshToken, params, verified);
+              } else if (arity == 6) {
+                self._verify(iss, sub, profile, accessToken, refreshToken, verified);
+              } else if (arity == 4) {
+                self._verify(iss, sub, profile, verified);
+              } else { // arity == 3
+                self._verify(iss, sub, verified);
+              }
+            }
+          }
+
+
+    } else {
     // The request being authenticated is initiating OpenID Connect
     // authentication.  Prior to redirecting to the provider, configuration will
     // be loaded.  The configuration is typically either pre-configured or
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
-  
+
+    log.info("OPENID CONNECT: We are in the OpenID Connect Inital Flow. Assumed because no auth code was in the query and we are not POST.")
+    log.info("");
+    log.info('Body received was: ', req.body);
+
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
     }
-  
+
     this.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
-      
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -299,12 +415,16 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       var params = self.authorizationParams(options);
       var params = {};
-      params['response_type'] = 'code';
+      params['response_type'] = self._responseType;
+      log.info('We are sending the response_type: ', self._responseType);
       params['client_id'] = config.clientID;
       params['redirect_uri'] = callbackURL;
+      params['response_mode'] = self._responseMode;
+      log.info('We are sending the response_mode: ', self._responseMode);
+      params['nonce'] = utils.uid(16);
       var scope = options.scope || self._scope;
       if (Array.isArray(scope)) { scope = scope.join(self._scopeSeparator); }
       if (scope) {
@@ -317,12 +437,13 @@ Strategy.prototype.authenticate = function(req, options) {
       //       session key.
       //var state = options.state;
       //if (state) { params.state = state; }
-      
+
       var state = utils.uid(16);
-      
+
       // TODO: Implement support for standard OpenID Connect params (display, prompt, etc.)
-      
+
       var location = config.authorizationURL + '?' + querystring.stringify(params);
+
       self.redirect(location);
     });
   }
@@ -361,7 +482,7 @@ Strategy.prototype.configure = function(identifier, done) {
   (function pass(i, err, config) {
     // an error or configuration was obtained, done
     if (err || config) { return done(err, config); }
-    
+
     var layer = stack[i];
     if (!layer) {
       // Strategy-specific functions did not result in obtaining configuration
@@ -369,7 +490,7 @@ Strategy.prototype.configure = function(identifier, done) {
       // to discover the provider's configuration.
       return setup(identifier, done);
     }
-    
+
     try {
       layer(identifier, function(e, c) { pass(i + 1, e, c); } )
     } catch (ex) {
@@ -422,5 +543,5 @@ Strategy.prototype._shouldLoadUserProfile = function(issuer, subject, done) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;


### PR DESCRIPTION
* Support for v1 or v2 of our API. You just change the knobs and the metadata endpoint!

* Massive update that fixes a lot that was wrong with the original OpenID Connect Implementation.
	* Lots of new knobs given to you that you can pass in. Look at the client_config.js example to see these. In detail:
	* You can now specify if user profile should be loaded. (HINT: You shouldn't - as we don't have a user profile lookup.) Default is to skip which you should for AzureAD and MSA. #51
	* Turns out that my OpenID Connect implementation only have OAuth2 query support, and passed code and tokens through such. This is against spec, against nature, and now fixed. #50
		* Both the id_token code and id_token flows now support POST and will do the right thing no matter if using v1 or v2. Fragment still not supported. #49
			* I've exposed this as a config setting you can pass: `responseType:`. The default is `id_token code` to match the rest of ADAL.
			* Login only `id_token` is now supported *through POST only*.
			* OAuth flows `code` and OAuth + OpenID Connect `id_token code` support query or POST response modes.
			* In addition, I've exposed this as a config setting you can pass: `responseMode:`. The default is `form_post`
	* In support of this, I've updated the app.js in /example to work no matter if using `id_token`, or `id_token code` for either v1 or v2 through unwise use of ORs.
	* Added nonce that is actually a nonce (`utils.uid(16)`)