### PR TITLE
B2C Support and more!

### DIFF
--- a/examples/login-oidc-b2c/README.md
+++ b/examples/login-oidc-b2c/README.md
@@ -1,0 +1,16 @@
+# SAML SSO Example  for Azure Active Directory
+
+[Passport](http://passportjs.org/) strategy for authenticating with Azure Active Directory using OIDC. 
+
+## Install
+
+	npm install
+
+## Usage
+
+node app
+
+
+
+## License
+Copyright (c) Microsoft.  All rights reserved. Licensed under the MIT License. 

--- a/examples/login-oidc-b2c/app.js
+++ b/examples/login-oidc-b2c/app.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  Apache License 2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var express = require('express');
+var cookieParser = require('cookie-parser');
+var expressSession = require('express-session');
+var bodyParser = require('body-parser');
+var passport = require('passport');
+var util = require('util');
+var bunyan = require('bunyan');
+var config = require('./client_config_b2c');
+var OIDCStrategy = require('../../lib/passport-azure-ad/index').OIDCStrategy;
+
+var log = bunyan.createLogger({
+    name: 'Microsoft OIDC Example Web Application'
+});
+
+// array to hold logged in users
+var users = [];
+
+// Passport session setup.
+//   To support persistent login sessions, Passport needs to be able to
+//   serialize users into and deserialize users out of the session.  Typically,
+//   this will be as simple as storing the user ID when serializing, and finding
+//   the user by ID when deserializing.
+passport.serializeUser(function(user, done) {
+  done(null, user.email);
+});
+
+passport.deserializeUser(function(id, done) {
+  findByEmail(id, function (err, user) {
+    done(err, user);
+  });
+});
+
+
+
+var findByEmail = function(email, fn) {
+  for (var i = 0, len = users.length; i < len; i++) {
+    var user = users[i];
+    log.info('we are using user: ', user);
+    if (user.email === email) {
+      return fn(null, user);
+    }
+  }
+  return fn(null, null);
+};
+
+// Use the OIDCStrategy within Passport.
+//   Strategies in passport require a `validate` function, which accept
+//   credentials (in this case, an OpenID identifier), and invoke a callback
+//   with a user object.
+passport.use(new OIDCStrategy({
+    callbackURL: config.creds.returnURL,
+    realm: config.creds.realm,
+    clientID: config.creds.clientID,
+    clientSecret: config.creds.clientSecret,
+    oidcIssuer: config.creds.issuer,
+    identityMetadata: config.creds.identityMetadata,
+    skipUserProfile: config.creds.skipUserProfile,
+    responseType: config.creds.responseType,
+    responseMode: config.creds.responseMode,
+    tenantName: config.creds.tenantName
+  },
+  function(iss, sub, profile, accessToken, refreshToken, done) {
+    if (!profile.email) {
+      return done(new Error("No email found"), null);
+    }
+    // asynchronous verification, for effect...
+    process.nextTick(function () {
+      findByEmail(profile.email, function(err, user) {
+        if (err) {
+          return done(err);
+        }
+        if (!user) {
+          // "Auto-registration"
+          users.push(profile);
+          return done(null, profile);
+        }
+        return done(null, user);
+      });
+    });
+  }
+));
+
+
+
+
+var app = express();
+
+// configure Express
+app.configure(function() {
+  app.set('views', __dirname + '/views');
+  app.set('view engine', 'ejs');
+  app.use(express.logger());
+  app.use(cookieParser());
+  app.use(expressSession({ secret: 'keyboard cat', resave: true, saveUninitialized: false }));
+  app.use(bodyParser.urlencoded({ extended : true }));
+  app.use(express.methodOverride());
+  app.use(passport.initialize());
+  app.use(passport.session());
+  app.use(app.router);
+  app.use(express.static(__dirname + '/../../public'));
+});
+
+
+app.get('/', function(req, res){
+  res.render('index', { user: req.user });
+});
+
+app.get('/account', ensureAuthenticated, function(req, res){
+  res.render('account', { user: req.user });
+});
+
+app.get('/login',
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login', failureFlash: true }),
+  function(req, res) {
+    log.info('Login was called in the Sample');
+    res.redirect('/');
+});
+
+// POST /auth/openid
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  The first step in OpenID authentication will involve redirecting
+//   the user to their OpenID provider.  After authenticating, the OpenID
+//   provider will redirect the user back to this application at
+//   /auth/openid/return
+app.get('/auth/openid',
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login', failureFlash: true }),
+  function(req, res) {
+    log.info('Authenitcation was called in the Sample');
+    res.redirect('/');
+  });
+
+// GET /auth/openid/return
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function function will be called,
+//   which, in this example, will redirect the user to the home page.
+app.get('/auth/openid/return',
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login', failureFlash: true }),
+  function(req, res) {
+    log.info('We received a return from AzureAD.');
+    res.redirect('/');
+  });
+
+// GET /auth/openid/return
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function function will be called,
+//   which, in this example, will redirect the user to the home page.
+app.post('/auth/openid/return',
+  passport.authenticate('azuread-openidconnect', { failureRedirect: '/login', failureFlash: true }),
+  function(req, res) {
+    log.info('We received a return from AzureAD.');
+    res.redirect('/');
+  });
+
+app.get('/logout', function(req, res){
+  req.logout();
+  res.redirect('/');
+});
+
+app.listen(3000);
+
+
+// Simple route middleware to ensure user is authenticated.
+//   Use this route middleware on any resource that needs to be protected.  If
+//   the request is authenticated (typically via a persistent login session),
+//   the request will proceed.  Otherwise, the user will be redirected to the
+//   login page.
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) { return next(); }
+  res.redirect('/login')
+}

--- a/examples/login-oidc-b2c/client_config_b2c.js
+++ b/examples/login-oidc-b2c/client_config_b2c.js
@@ -1,0 +1,13 @@
+  // Don't commit this file to your public repos. This config is for first-run
+  //
+ exports.creds = {
+ 	returnURL: 'http://localhost:3000/auth/openid/return',
+ 	identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
+ 	clientID: '519ea014-04c9-4839-9b4a-8a604aff827a',
+ 	clientSecret: '06fedk9aosPLjHyodC329VH', // if you are doing code or id_token code
+ 	skipUserProfile: true, // for AzureAD should be set to true.
+ 	responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
+ 	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
+ 	//scope: ['email', 'profile'] // additional scopes you may wish to pass
+ 	tenantName: 'hypercubeb2c.onmicrosoft.com'
+ 	};

--- a/examples/login-oidc-b2c/package.json
+++ b/examples/login-oidc-b2c/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "passport-azure-ad-login-oidc",
+    "version": "0.0.1",
+    "dependencies": {
+        "express": "3.x",
+        "ejs": ">= 0.0.0",
+        "ejs-locals": ">= 0.0.0",
+        "bunyan": "*",
+        "assert-plus": "*",
+        "passport": "*"
+    }
+}

--- a/examples/login-oidc-b2c/routes/index.js
+++ b/examples/login-oidc-b2c/routes/index.js
@@ -1,0 +1,8 @@
+
+/*
+ * GET home page.
+ */
+
+exports.index = function(req, res){
+  res.render('index', { title: 'Express' });
+};

--- a/examples/login-oidc-b2c/routes/user.js
+++ b/examples/login-oidc-b2c/routes/user.js
@@ -1,0 +1,8 @@
+
+/*
+ * GET users listing.
+ */
+
+exports.list = function(req, res){
+  res.send("respond with a resource");
+};

--- a/examples/login-oidc-b2c/views/account.ejs
+++ b/examples/login-oidc-b2c/views/account.ejs
@@ -1,0 +1,14 @@
+<% if (!user) { %>
+	<h2>Welcome! Please log in.</h2>
+	<a href="/login">Log In</a>
+<% } else { %>
+<p>displayName: <%= user.displayName %></p>
+<p>givenName: <%= user.name.givenName %></p>
+<p>familyName: <%= user.name.familyName %></p>
+<p>UPN: <%= user._json.upn %></p>
+<p>Profile ID: <%= user.id %></p>
+<p>Full Claimes</p>
+<%- JSON.stringify(user) %>
+<p></p>
+<a href="/logout">Log Out</a>
+<% } %>

--- a/examples/login-oidc-b2c/views/index.ejs
+++ b/examples/login-oidc-b2c/views/index.ejs
@@ -1,0 +1,10 @@
+<% if (!user) { %>
+	<h2>Welcome! Please log in.</h2>
+	<a href="/login/?p=B2C_1_B2CSU">Sign In</a>
+	<a href="/login/?p=b2ctestsigninpolicy">Sign Up</a>
+	<a href="/login/">Sign In Old</a>
+<% } else { %>
+	<h2>Hello, <%= user.displayName %>.</h2>
+	<a href="/account">Account Info</a></br>
+	<a href="/logout">Log Out</a>
+<% } %>

--- a/examples/login-oidc-b2c/views/layout.ejs
+++ b/examples/login-oidc-b2c/views/layout.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Passport-OpenID Example</title>
+	</head>
+	<body>
+		<% if (!user) { %>
+			<p>
+			<a href="/">Home</a> | 
+			<a href="/login/?p=B2C_1_B2CSU">Sign Up</a>
+			<a href="/login/?p=b2ctestsigninpolicy">Sign Up</a>
+			</p>
+		<% } else { %>
+			<p>
+			<a href="/">Home</a> | 
+			<a href="/account">Account</a> | 
+			<a href="/logout">Log Out</a>
+			</p>
+		<% } %>
+		<%- body %>
+	</body>
+</html>

--- a/examples/login-oidc/client_config_v1.js
+++ b/examples/login-oidc/client_config_v1.js
@@ -3,10 +3,10 @@
  exports.creds = {
  	returnURL: 'http://localhost:3000/auth/openid/return',
  	identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
- 	clientID: '<your app id>',
- 	clientSecret: '<your app secret>', // if you are doing code or id_token code
+ 	clientID: 'c9655d1d-f356-46a7-afe1-431c0d6eeb37',
+ 	clientSecret: 'ojEsyBUEv0huRz7gKRqbHmv9WbrGXKFtQ0w+/UNQT1E=', // if you are doing code or id_token code
  	skipUserProfile: true, // for AzureAD should be set to true.
  	responseType: 'id_token code', // for login only flows use id_token. For accessing resources use `id_token code`
- 	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
+ 	responseMode: 'query', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
  	};

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -10,11 +10,20 @@ var passport = require('passport')
   , setup = require('./oidcsetup')
   , bunyan = require('bunyan')
   , InternalOAuthError = require('./errors/internaloautherror')
-  , Metadata = require('./metadata').Metadata;
+  , Metadata = require('./metadata').Metadata
+  , async = require('async');
+
+var cacheManager = require('cache-manager');
 
 var log = bunyan.createLogger({
     name: 'Microsoft OIDC Passport Strategy'
 });
+
+var memoryCache = cacheManager.caching({store: 'memory', max: 3600, ttl: 1800/*seconds*/});
+var ttl = 1800; // 30 minutes cache
+
+
+// Note: callback is optional in set() and del().
 
 /**
  * `Strategy` constructor.
@@ -31,27 +40,14 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'azuread-openidconnect';
   this._verify = verify;
-
-      if (options.identityMetadata) {
-
-        log.info('Metadata url provided to Strategy was: ', options.identityMetadata);
-        this.metadata = new Metadata(options.identityMetadata, "oidc");
-    }
+  this._configurers = [];
+  this._cacheKey = 'ordinary';
 
     if (!options.identityMetadata) {
         log.warn("No options was presented to Strategy as required.");
-        throw new TypeError('OIDCBearerStrategy requires either a PEM encoded public key or a metadata location that contains cert data for RSA and ECDSA callback.');
+        throw new TypeError('OIDCStrategy requires either a PEM encoded public key or a metadata location that contains cert data for RSA and ECDSA callback.');
     }
 
-      // Token validation settings. Hopefully most of these will be pulled from the metadata and this is not needed
-
-
-    this.metadata.fetch(function(err) {
-        if (err) {
-            throw new Error("Unable to fetch metadata: " + err);
-        }
-
-    });
 
   }
 /**
@@ -68,8 +64,61 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req, options) {
-  options = this.setOptions(options) || {};
   var self = this;
+
+async.waterfall([ 
+
+  function(next) {
+
+      // B2C interception
+      // 
+    
+
+    // We listen for the p paramter in any response and set it. If it has been set already and in memory (profile) we skip this as it's not necessary to set again.
+    if (req.query.p) {
+
+    log.info("B2C: Found a policy inside of the login request. This is a B2C tenant!")
+    log.info("");
+
+    if (!self._options.tenantName) {
+        log.warn("For B2C For B2C you must specify a tenant name, none was presented to Strategy as required. (example: tenantName:contoso.onmicrosoft.com");
+        throw new TypeError('OIDCStrategy requires you specify a tenant name to Strategy if using a B2C tenant. (example: tenantName:contoso.onmicrosoft.com');
+    }
+
+    var policy = req.query.p;
+   
+        metadata = self._options.identityMetadata.replace("common", self._options.tenantName);
+        metadata = metadata.concat('?p=' + policy);
+        self._cacheKey = policy; // this policy will become cache key.
+
+        log.info('B2C: New Metadata url provided to Strategy was: ', metadata);
+        
+
+    } else {
+      metadata = self._options.identityMetadata;
+    }
+
+    next(null, metadata);
+
+},
+
+
+function(metadata, next) {
+// Once loaded, we now set options.
+// 
+
+self.setOptions(self._options, metadata, function(err, options) {
+  if (err) { return self.error(err); } 
+  self.options = options;
+  return next(null);
+});
+
+
+},
+
+function(next) {
+
+
 
   log.info('Query received was: ', req.query);
 
@@ -94,7 +143,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
     log.info("OAUTH2: Got access code: ", code);
 
-    this.configure(null, function(err, config) {
+    self.configure(null, function(err, config) {
       if (err) { return self.error(err); }
 
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
@@ -325,7 +374,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
               try {
 
-                profile.id = jwtClaims.sub;
+                profile.id = jwtClaims.oid;
                 // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
                 // "sub" key was named "user_id".  Many providers still use the old
                 // key, so fallback to that.
@@ -338,7 +387,7 @@ Strategy.prototype.authenticate = function(req, options) {
                                  givenName: jwtClaims.given_name,
                                  middleName: jwtClaims.middle_name };
 
-                profile.email = profile.email = jwtClaims.upn || jwtClaims.preferred_username;
+                profile.email = profile.email = jwtClaims.upn || jwtClaims.preferred_username || jwtClaims.aud;
 
                 profile._raw = jwtClaimsStr;
                 profile._json =  jwtClaims;
@@ -406,7 +455,9 @@ Strategy.prototype.authenticate = function(req, options) {
       identifier = req.query[this._identifierField];
     }
 
-    this.configure(identifier, function(err, config) {
+
+
+    self.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
 
       var callbackURL = options.callbackURL || config.callbackURL;
@@ -435,6 +486,10 @@ Strategy.prototype.authenticate = function(req, options) {
       } else {
         params.scope = 'openid';
       }
+
+      //if (policy) { params['p'] = policy; }; // Policy parameter should be included.
+
+
       // TODO: Add support for automatically generating a random state for verification.
       // TODO: Make state optional, if `config` disables it and supplies an alternative
       //       session key.
@@ -445,11 +500,27 @@ Strategy.prototype.authenticate = function(req, options) {
 
       // TODO: Implement support for standard OpenID Connect params (display, prompt, etc.)
 
-      var location = config.authorizationURL + '?' + querystring.stringify(params);
+      if (req.query.p) { 
+
+        var location = config.authorizationURL + '&' + querystring.stringify(params);
+
+      }else {
+
+        var location = config.authorizationURL + '?' + querystring.stringify(params);
+      }
+
+      
 
       self.redirect(location);
     });
-  }
+  } 
+
+  next(null);
+
+}  ], function(err) { //This function gets called after the two tasks have called their "task callbacks"
+        if (err) return next(err); 
+
+      });
 }
 
 /**
@@ -464,37 +535,74 @@ Strategy.prototype.authenticate = function(req, options) {
  * @param {Object} options
  * @return {Object} options
  */
- Strategy.prototype.setOptions = function(options) {
+ Strategy.prototype.setOptions = function(options, metadata, done) {
+var self = this;
 
+// Loading metadata from endpoint.
+// 
+// 
+ async.waterfall([
+          
+            // fetch the metadata
+    function loadMetadata(next) {
+
+    log.info("Parsing Metadata");
+    log.info("Metadata we have is: ", metadata);
+    
+
+
+    memoryCache.wrap(self._cacheKey, function (cacheCallback) {
+    metadata = new Metadata(metadata, "oidc");
+    metadata.fetch(function(err) {
+        if (err) {
+            return cacheCallback(new Error("Unable to fetch metadata: " + err));
+        } else {
+              return cacheCallback(null, metadata); }
+        }); }, {ttl: ttl}, next);
+    
+
+  },
+function loadOptions(metadata, next) {
+
+log.info("Setting options");
     // TODO: What's the recommended field name for OpenID Connect?
-  this._identifierField = this._options.identifierField || 'openid_identifier';
-  this._scope = this._options.scope;
-  this._scopeSeparator = this._options.scopeSeparator || ' ';
-  this._passReqToCallback = this._options.passReqToCallback;
-  this._skipUserProfile = this._options.skipUserProfile || false;
-  this._responseType = this._options.responseType || 'code id_token';
-  this._responseMode = this._options.responseMode || 'form_post';
+  self._identifierField = options.identifierField || 'openid_identifier';
+  self._scope = options.scope;
+  self_scopeSeparator = options.scopeSeparator || ' ';
+  self._passReqToCallback = options.passReqToCallback;
+  self._skipUserProfile = options.skipUserProfile || false;
+  self._responseType = options.responseType || 'code id_token';
+  self._responseMode = options.responseMode || 'form_post';
 
-  this._configurers = [];
+
 
   // https://login.microsoftonline.com/common/.well-known/openid-configuration
   // NOTE: We will always use the values returned from the metadata endpoint. If they conflict with the configuration below the
   // values from the metadata endpoint will be used instead.
   //
-  options.authorizationURL = this.metadata.oidc.auth_endpoint;
-  options.tokenURL = this.metadata.oidc.token_endpoint;
-  options.userInfoURL = this.metadata.oidc.userinfo_endpoint;
-  options.revocationURL = this.metadata.oidc.end_session_endpoint;
-  options.tokenInfoURL = this.metadata.oidc.tokeninfo_endpoint || null;
-  options.oidcIssuer = this.metadata.oidc.issuer;
-  options.clientID = this._options.clientID;
-  options.clientSecret = this._options.clientSecret;
-  options.callbackURL = this._options.callbackURL;
+  options.authorizationURL = metadata.oidc.auth_endpoint;
+  options.tokenURL = metadata.oidc.token_endpoint;
+  options.userInfoURL = metadata.oidc.userinfo_endpoint;
+  options.revocationURL = metadata.oidc.end_session_endpoint;
+  options.tokenInfoURL = metadata.oidc.tokeninfo_endpoint || null;
+  options.oidcIssuer = metadata.oidc.issuer;
+  options.clientID = options.clientID;
+  options.clientSecret = options.clientSecret;
+  options.callbackURL = options.callbackURL;
 
-  if (options.authorizationURL && options.tokenURL) {
+  log.info("Our options looks like this: ", options);
+
+  next(null, options); 
+},
+
+  function setConfiguration(options, next) {
+
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
-    this.configure(function(identifier, done) {
+    // 
+    // 
+    log.info("Setting a configuration for later");
+    self.configure(function(identifier, done) {
       return done(null, {
         authorizationURL: options.authorizationURL,
         tokenURL: options.tokenURL,
@@ -507,9 +615,14 @@ Strategy.prototype.authenticate = function(req, options) {
         oidcIssuer: options.oidcIssuer
       });
     });
-  }
 
-  return options;
+
+  next(null, options);
+
+},        
+], function(err) {
+            done(err, options);
+        });
 
 }
 /**
@@ -577,8 +690,11 @@ Strategy.prototype.configure = function(identifier, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function(options) {
+
+
   return {};
 }
+
 
 /**
  * Check if should load user profile, contingent upon options.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "openid": "*",
     "oauth": "*",
     "webfinger": "0.3.x",
-    "bunyan": "*"
+    "bunyan": "*",
+    "cache-manager": "*"
   },
   "peerDependencies": {
     "body-parser": "^1.12.3",


### PR DESCRIPTION
Another big fancy update!

* B2C Support - when it launches you can easily use policies in your node.js application! Just check out /examples/login-oidc-b2c for details. 
* You just specify the tenantName: and then add some routes.

Biggest speed improvement: I've implemented caching of the metadata with cache-manager.
* This increases speed amazingly.
* I needed to do this because now we load metadata at clicktime and not at server launch, so this was required.
* I set the cache expiry to 30 mintues for now, we'll see how that goes. May expose it out in config if users want.

