### PR TITLE
Allow resource parameter, response mode, and response type options to be set

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -472,13 +472,14 @@ function(next) {
 
       var params = self.authorizationParams(options);
       var params = {};
-      params['response_type'] = self._responseType;
-      log.info('We are sending the response_type: ', self._responseType);
+      params['response_type'] = options.responseType || self._responseType;
+      log.info('We are sending the response_type: ', params['response_type']);
       params['client_id'] = config.clientID;
       params['redirect_uri'] = callbackURL;
-      params['response_mode'] = self._responseMode;
-      log.info('We are sending the response_mode: ', self._responseMode);
+      params['response_mode'] = options.responseMode || self._responseMode;
+      log.info('We are sending the response_mode: ', params['response_mode']);
       params['nonce'] = utils.uid(16);
+      if (options.resource) { params['resource'] = options.resource; }
       var scope = options.scope || self._scope;
       if (Array.isArray(scope)) { scope = scope.join(self._scopeSeparator); }
       if (scope) {


### PR DESCRIPTION
- Include the "resource" parameter when there is one...otherwise the request to get the access token will fail.

- Allow local options of response mode and response type to override the global options