### PR TITLE
Fix strategy tests

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -636,7 +636,6 @@ log.info("Setting options");
         var config = {
         clientID: Validator.isNonEmpty,
         callbackURL: Validator.isNonEmpty,
-        tokenURL: Validator.isNonEmpty,
         responseType: Validator.isTypeLegal,
         responseMode: Validator.isModeLegal,
         authorizationURL: Validator.isURL,

--- a/lib/passport-azure-ad/validator.js
+++ b/lib/passport-azure-ad/validator.js
@@ -23,11 +23,11 @@
 
 var types = {};
 
-var Validator = function(config) {
+var Validator = function (config) {
   this.config = config;
 };
 
-Validator.prototype.validate = function(options) {
+Validator.prototype.validate = function (options) {
 
   var item,
     type,
@@ -45,10 +45,7 @@ Validator.prototype.validate = function(options) {
       }
       checker = types[type];
       if (!checker) { // missing required checker
-        throw {
-          name: 'ValidationError',
-          message: 'No handler to validate type ' + type + ' for item ' + item
-        };
+        throw new TypeError('No handler to validate type ' + type + ' for item ' + item);
       }
 
       if (!checker.validate(options[item])) {
@@ -65,7 +62,7 @@ Validator.prototype.validate = function(options) {
 
 Validator.isNonEmpty = 'isNonEmpty';
 types.isNonEmpty = {
-  validate: function(value) {
+  validate: function (value) {
     return value !== '' && value !== undefined && value !== null;
   },
   error: 'The value cannot be empty'
@@ -73,7 +70,7 @@ types.isNonEmpty = {
 
 Validator.isTypeLegal = 'isTypeLegal';
 types.isTypeLegal = {
-  validate: function(value) {
+  validate: function (value) {
     return value === 'id_token' || value === 'id_token code' || value === 'code';
   },
   error: 'The responseType: must be either id_token, id_token code, or code.'
@@ -81,7 +78,7 @@ types.isTypeLegal = {
 
 Validator.isModeLegal = 'isModeLegal';
 types.isModeLegal = {
-  validate: function(value) {
+  validate: function (value) {
     return value === 'query' || value === 'form_post';
   },
   error: 'The responseMode: must be either query or form_post.'
@@ -90,18 +87,18 @@ types.isModeLegal = {
 Validator.isURL = 'isURL';
 types.isURL = {
 
-  validate: function(value) {
-  var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
-  '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
-  '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
-  '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
-  '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
-  '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
-  if(!pattern.test(value)) {
-    return false;
-  } else {
-    return true;
-  }
+  validate: function (value) {
+    var pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locator
+    if (!pattern.test(value)) {
+      return false;
+    } else {
+      return true;
+    }
   },
   error: 'The URL must be valid and be https://'
 };

--- a/test/oidc_test.js
+++ b/test/oidc_test.js
@@ -1,3 +1,4 @@
+/* global process */
 /*
  Copyright (c) Microsoft Open Technologies, Inc.
  All Rights Reserved
@@ -41,108 +42,105 @@ var OidcStrategy = require('../lib/passport-azure-ad/index').OIDCStrategy;
 
 
 exports['oidc'] = {
-
-    'no args': function(test) {
-        test.expect(1);
-        // tests here
-
-        test.throws(
-            function() {
-                new OIDCStrategy();
-            },
-            Error,
-            'Should fail with no arguments)'
-        );
-
-        test.done();
+  'no args': function (test) {
+    test.expect(1);
+    // tests here
+    test.throws(function () {
+      new OidcStrategy();
     },
-    'no verify function': function(test) {
-        test.expect(1);
-        // tests here
+      TypeError,
+      'Should fail with no arguments)'
+      );
 
-        test.throws(
-            function() {
-                new OIDCStrategy({}, null);
-            },
-            Error,
-            'Should fail with no verify function (2nd argument)'
-        );
-
-        test.done();
+    test.done();
+  },
+  'no verify function': function (test) {
+    test.expect(1);
+    // tests here
+    test.throws(function () {
+      new OidcStrategy({}, null);
     },
+      TypeError,
+      'Should fail with no verify function (2nd argument)'
+      );
 
-    'no options': function(test) {
-        test.expect(1);
-        // tests here
+    test.done();
+  },
 
-        test.throws(
-            function() {
-                new OIDCStrategy({}, function() {});
-            },
-            Error,
-            'Should fail with no OIDC config options'
-        );
+  'no options': function (test) {
+    test.expect(1);
+    // tests here
 
-        test.done();
-    },
-        'with missing option resposneType': function(test) {
-        test.expect(1);
-        // tests here
+    test.throws(
+      function () {
+        new OidcStrategy({}, function () { });
+      },
+      TypeError,
+      'Should fail with no OIDC config options'
+      );
 
-var oidcConfig = {
-            // required options
-            identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-            responseType: 'id_tokennn', // for login only flows use id_token. For accessing resources use `id_token code`
-        };
-        test.throws(
-            function() {
-                new OIDCStrategy(oidcConfig, function() {});
-            },
-            Error,
-            'Should fail with wrong reponses config options'
-        );
+    test.done();
+  },
+  'with missing option resposneType': function (test) {
+    test.expect(1);
+    // tests here
 
-        test.done();
-    },
-    'with missing option resposneMode': function(test) {
-        test.expect(1);
-        // tests here
+    var oidcConfig = {
+      // required options
+      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      responseType: 'id_tokennn', // for login only flows use id_token. For accessing resources use `id_token code`
+    };
+    test.throws(
+      function () {
+        var s = new OidcStrategy(oidcConfig, function () { });
+        s.loadOptions(oidcConfig, function () { });
+      },
+      TypeError,
+      'Should fail with wrong reponses config options'
+      );
 
-var oidcConfig = {
-            // required options
-            identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-            responseMode: 'fragment', // For login only flows we should have token passed back to us in a POST
-        };
-        test.throws(
-            function() {
-                new OIDCStrategy(oidcConfig, function() {});
-            },
-            Error,
-            'Should fail with wrong reponses config options'
-        );
+    test.done();
+  },
+  'with missing option resposneMode': function (test) {
+    test.expect(1);
+    // tests here
 
-        test.done();
-    },
-    'with options': function(test) {
-        test.expect(1);
-        // tests here
+    var oidcConfig = {
+      // required options
+      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      responseMode: 'fragment', // For login only flows we should have token passed back to us in a POST
+    };
+    test.throws(
+      function () {
+        var s = new OidcStrategy(oidcConfig, function () { });
+        s.loadOptions(oidcConfig, function () { });
+      },
+      Error,
+      'Should fail with wrong reponses config options'
+      );
 
-        var oidcConfig = {
-            // required options
-            identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
-            issuer: 'http://localhost:3000' // this is the URI you entered for APP ID URI when configuring SSO for you app on Azure AAD
-        };
+    test.done();
+  },
+  'with options': function (test) {
+    test.expect(1);
+    // tests here
 
-        test.doesNotThrow(
-            function() {
-                new OidcStrategy(oidcConfig, function() {});
-            },
-            Error,
-            'Should not fail with proper OIDC config options'
-        );
+    var oidcConfig = {
+      // required options
+      identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+      issuer: 'http://localhost:3000' // this is the URI you entered for APP ID URI when configuring SSO for you app on Azure AAD
+    };
 
-        test.done();
-    }
+    test.doesNotThrow(
+      function () {
+        new OidcStrategy(oidcConfig, function () { });
+      },
+      Error,
+      'Should not fail with proper OIDC config options'
+      );
+
+    test.done();
+  }
 
 
 };


### PR DESCRIPTION
Several tests in the `oidc-tests.js` file were not actually exercising the product as they throw a ReferenceError, which was caught by the test.

This PR includes two fixes:
1. Fix `oidc-tests.js` tests to actually test the product under test.
2. Fix duplicate tokenURL validator configuration entry.
  a. The isURL validator indirectly checks for non-empty strings which was the other configured validator.