### PR TITLE
Fixed logging, ReqToCallaback, and passing state.

### DIFF
--- a/examples/login-oidc-b2c/app.js
+++ b/examples/login-oidc-b2c/app.js
@@ -33,8 +33,23 @@ var config = require('./client_config_b2c');
 var OIDCStrategy = require('../../lib/passport-azure-ad/index').OIDCStrategy;
 
 var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Example Web Application'
+    name: 'Microsoft OIDC Example Web Application',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
+  // if logging level specified, switch to it.
+  if (config.creds.loggingLevel) { log.levels("console", config.creds.loggingLevel); }
+
 
 // array to hold logged in users
 var users = [];
@@ -97,6 +112,7 @@ passport.use(new OIDCStrategy({
     tenantName: config.creds.tenantName,
     validateIssuer: config.creds.validateIssuer,
     passReqToCallback: config.creds.passReqToCallback,
+    loggingLevel: config.creds.loggingLevel,
     scope: config.creds.scope
   },
   // if you wish to receive the req, use function(req, profile, done)

--- a/examples/login-oidc-b2c/app.js
+++ b/examples/login-oidc-b2c/app.js
@@ -104,7 +104,6 @@ passport.use(new OIDCStrategy({
     realm: config.creds.realm,
     clientID: config.creds.clientID,
     clientSecret: config.creds.clientSecret,
-    oidcIssuer: config.creds.issuer,
     identityMetadata: config.creds.identityMetadata,
     skipUserProfile: config.creds.skipUserProfile,
     responseType: config.creds.responseType,

--- a/examples/login-oidc-b2c/app.js
+++ b/examples/login-oidc-b2c/app.js
@@ -96,9 +96,11 @@ passport.use(new OIDCStrategy({
     responseMode: config.creds.responseMode,
     tenantName: config.creds.tenantName,
     validateIssuer: config.creds.validateIssuer,
+    passReqToCallback: config.creds.passReqToCallback,
     scope: config.creds.scope
   },
-  function(iss, sub, profile, accessToken, refreshToken, done) {
+  // if you wish to receive the req, use function(req, profile, done)
+  function(profile, done) {
     if (!profile.email) {
       return done(new Error("No email found"), null);
     }

--- a/examples/login-oidc-b2c/client_config_b2c.js
+++ b/examples/login-oidc-b2c/client_config_b2c.js
@@ -10,5 +10,6 @@
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
  	tenantName: 'kidventusb2c.onmicrosoft', 
  	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
- 	passReqToCallback: false
+ 	passReqToCallback: false,
+ 	loggingLevel: 'info' // valid are 'info', 'warn', 'error'. Error always goes to stderr in Unix.
  	};

--- a/examples/login-oidc-b2c/client_config_b2c.js
+++ b/examples/login-oidc-b2c/client_config_b2c.js
@@ -8,6 +8,7 @@
  	responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
  	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
- 	tenantName: 'kidventusb2c.onmicrosoft.com',
- 	validateIssuer: true
+ 	tenantName: 'kidventusb2c.onmicrosoft', 
+ 	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
+ 	passReqToCallback: false
  	};

--- a/examples/login-oidc/app.js
+++ b/examples/login-oidc/app.js
@@ -29,12 +29,26 @@ var expressSession = require('express-session');
 var bodyParser = require('body-parser');
 var passport = require('passport');
 var bunyan = require('bunyan');
-var config = require('./client_config_v1');
+var config = require('./client_config_v2');
 var OIDCStrategy = require('../../lib/passport-azure-ad/index').OIDCStrategy;
 
 var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Example Web Application'
+    name: 'Microsoft OIDC Example Web Application',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
+  // if logging level specified, switch to it.
+  if (config.creds.loggingLevel) { log.levels("console", config.creds.loggingLevel); }
 
 // array to hold logged in users
 var users = [];
@@ -95,7 +109,8 @@ passport.use(new OIDCStrategy({
     responseType: config.creds.responseType,
     responseMode: config.creds.responseMode,
     validateIssuer: config.creds.validateIssuer,
-    passReqToCallback: config.creds.passReqToCallback
+    passReqToCallback: config.creds.passReqToCallback,
+    loggingLevel: config.creds.loggingLevel
   },
 
   // if you wish to receive the req, use function(req, profile, done)

--- a/examples/login-oidc/app.js
+++ b/examples/login-oidc/app.js
@@ -29,7 +29,7 @@ var expressSession = require('express-session');
 var bodyParser = require('body-parser');
 var passport = require('passport');
 var bunyan = require('bunyan');
-var config = require('./client_config_v2');
+var config = require('./client_config_v1');
 var OIDCStrategy = require('../../lib/passport-azure-ad/index').OIDCStrategy;
 
 var log = bunyan.createLogger({
@@ -94,9 +94,12 @@ passport.use(new OIDCStrategy({
     skipUserProfile: config.creds.skipUserProfile,
     responseType: config.creds.responseType,
     responseMode: config.creds.responseMode,
-    validateIssuer: config.creds.validateIssuer
+    validateIssuer: config.creds.validateIssuer,
+    passReqToCallback: config.creds.passReqToCallback
   },
-  function(iss, sub, profile, accessToken, refreshToken, done) {
+
+  // if you wish to receive the req, use function(req, profile, done)
+  function(profile, done) {
     if (!profile.email) {
       return done(new Error("No email found"), null);
     }

--- a/examples/login-oidc/client_config_v1.js
+++ b/examples/login-oidc/client_config_v1.js
@@ -9,5 +9,6 @@
  	responseType: 'id_token code', // for login only flows use id_token. For accessing resources use `id_token code`
  	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'], // additional scopes you may wish to pass
- 	validateIssuer: false
+ 	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
+ 	passReqToCallback: false
  	};

--- a/examples/login-oidc/client_config_v1.js
+++ b/examples/login-oidc/client_config_v1.js
@@ -10,5 +10,6 @@
  	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'], // additional scopes you may wish to pass
  	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
- 	passReqToCallback: false
+ 	passReqToCallback: false,
+ 	loggingLevel: 'info' // valid are 'info', 'warn', 'error'. Error always goes to stderr in Unix.
  	};

--- a/examples/login-oidc/client_config_v2.js
+++ b/examples/login-oidc/client_config_v2.js
@@ -9,5 +9,6 @@
  	responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
  	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
- 	validateIssuer: false
+ 	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
+ 	passReqToCallback: false
  	};

--- a/examples/login-oidc/client_config_v2.js
+++ b/examples/login-oidc/client_config_v2.js
@@ -10,5 +10,6 @@
  	responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
  	//scope: ['email', 'profile'] // additional scopes you may wish to pass
  	validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in
- 	passReqToCallback: false
+ 	passReqToCallback: false,
+ 	loggingLevel: 'info' // valid are 'info', 'warn', 'error'. Error always goes to stderr in Unix.
  	};

--- a/examples/server-oauth2-b2c/server.js
+++ b/examples/server-oauth2-b2c/server.js
@@ -42,7 +42,8 @@ var options = {
     tenantName: config.creds.tenantName,
     policyName: config.creds.policyName,
     validateIssuer: config.creds.validateIssuer,
-    audience: config.creds.audience
+    audience: config.creds.audience,
+    passReqToCallback: config.creds.passReqToCallback
 
 };
 

--- a/examples/server-oauth2-b2c/server.js
+++ b/examples/server-oauth2-b2c/server.js
@@ -43,7 +43,8 @@ var options = {
     policyName: config.creds.policyName,
     validateIssuer: config.creds.validateIssuer,
     audience: config.creds.audience,
-    passReqToCallback: config.creds.passReqToCallback
+    passReqToCallback: config.creds.passReqToCallback,
+    loggingLevel: config.creds.loggingLevel
 
 };
 
@@ -53,8 +54,22 @@ var owner = null;
 
 // Our logger
 var log = bunyan.createLogger({
-    name: 'Windows Azure Active Directory Bearer Sample'
+    name: 'Windows Azure Active Directory Bearer Sample',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
+  // if logging level specified, switch to it.
+  if (config.creds.loggingLevel) { log.levels("console", config.creds.loggingLevel); }
 
 // MongoDB setup
 // Setup some configuration

--- a/examples/server-oauth2-b2c/server_config.js
+++ b/examples/server-oauth2-b2c/server_config.js
@@ -8,7 +8,8 @@
      tenantName:'hypercubeb2c.onmicrosoft.com',
      policyName:'B2C_1_b2c_node_signin',
      validateIssuer: false,
-     passReqToCallback: false
+     passReqToCallback: false,
+     loggingLevel: 'info' // valid are 'info', 'warn', 'error'. Error always goes to stderr in Unix.
  };
 
 

--- a/examples/server-oauth2-b2c/server_config.js
+++ b/examples/server-oauth2-b2c/server_config.js
@@ -3,11 +3,12 @@
      mongoose_auth_local: 'mongodb://localhost/tasklist', // Your mongo auth uri goes here
      clientID: '8fcf9b97-0489-4ead-b1eb-23254690dddc',
      clientSecret: 'LlFBJFY3Y2J9YnhBLW1UKDZNRSg=',
-     audience: 'http://kidventus.net/TodoListService',
+     audience: 'http://kidventus.net/tasks',
      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
      tenantName:'hypercubeb2c.onmicrosoft.com',
      policyName:'B2C_1_b2c_node_signin',
-     validateIssuer: true
+     validateIssuer: false,
+     passReqToCallback: false
  };
 
 

--- a/examples/server-oauth2/server.js
+++ b/examples/server-oauth2/server.js
@@ -39,7 +39,8 @@ var options = {
     identityMetadata: config.creds.identityMetadata,
     clientID: config.creds.clientID,
     validateIssuer: config.creds.validateIssuer,
-    audience: config.creds.audience
+    audience: config.creds.audience,
+    passReqToCallback: config.creds.passReqToCallback
 
 };
 

--- a/examples/server-oauth2/server.js
+++ b/examples/server-oauth2/server.js
@@ -40,7 +40,8 @@ var options = {
     clientID: config.creds.clientID,
     validateIssuer: config.creds.validateIssuer,
     audience: config.creds.audience,
-    passReqToCallback: config.creds.passReqToCallback
+    passReqToCallback: config.creds.passReqToCallback,
+    loggingLevel: config.creds.loggingLevel
 
 };
 
@@ -50,8 +51,22 @@ var owner = null;
 
 // Our logger
 var log = bunyan.createLogger({
-    name: 'Windows Azure Active Directory Bearer Sample'
+    name: 'Windows Azure Active Directory Bearer Sample',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
+  // if logging level specified, switch to it.
+  if (config.creds.loggingLevel) { log.levels("console", config.creds.loggingLevel); }
 
 // MongoDB setup
 // Setup some configuration

--- a/examples/server-oauth2/server_config.js
+++ b/examples/server-oauth2/server_config.js
@@ -2,9 +2,13 @@
  exports.creds = {
      mongoose_auth_local: 'mongodb://localhost/tasklist', // Your mongo auth uri goes here
      clientID: 'cff56d8f-f602-4afd-94e4-c95b76f1c81e',
-     audience: 'http://kidventus.net/TodoListService',
-     identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration', // For using Microsoft you should never need to change this.
-     validateIssuer: false
+     audience: 'https://kidventus.net/tasks',
+    // you cannot have users from multiple tenants sign in to your server unless you use the common endpoint
+ 	// example: https://login.microsoftonline.com/common/.well-known/openid-configuration
+     identityMetadata: 'https://login.microsoftonline.com/cff56d8f-f602-4afd-94e4-c95b76f1c81e/.well-known/openid-configuration', 
+     validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in to uyour server
+     passReqToCallback: false
+
  };
 
 

--- a/examples/server-oauth2/server_config.js
+++ b/examples/server-oauth2/server_config.js
@@ -7,7 +7,8 @@
  	// example: https://login.microsoftonline.com/common/.well-known/openid-configuration
      identityMetadata: 'https://login.microsoftonline.com/cff56d8f-f602-4afd-94e4-c95b76f1c81e/.well-known/openid-configuration', 
      validateIssuer: true, // if you have validation on, you cannot have users from multiple tenants sign in to uyour server
-     passReqToCallback: false
+     passReqToCallback: false,
+     loggingLevel: 'info' // valid are 'info', 'warn', 'error'. Error always goes to stderr in Unix.
 
  };
 

--- a/lib/passport-azure-ad/bearerstrategy.js
+++ b/lib/passport-azure-ad/bearerstrategy.js
@@ -18,27 +18,12 @@
 
 "use strict";
 
-var bunyan = require('bunyan'),
-BearerStrategy = require('passport-http-bearer').Strategy,
+var BearerStrategy = require('passport-http-bearer').Strategy,
 util = require('util'),
 jwt = require('jsonwebtoken'),
 Metadata = require('./metadata').Metadata,
+Log = require('./logging').getLogger,
 jws = require('jws');
-
-var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: OAuth Bearer Strategy',
-         streams: [
-        {
-            stream: process.stderr,
-            level: "error",
-            name: "error"
-        }, 
-        {
-            stream: process.stdout,
-            level: "warn",
-            name: "console"
-        }, ]
-});
 
 
 var PEMkey = null;
@@ -92,6 +77,8 @@ var PEMkey = null;
 function Strategy(options, verify) {
 /*jshint validthis: true */
 
+    var log = new Log("AzureAD: Bearer Strategy");
+
     // if logging level specified, switch to it.
     if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
 
@@ -115,12 +102,10 @@ if (options.policyName) {
         } 
     }
 
-
-    // if you want to check JWT issuer that is not in the token (not recommended), provide a value here
-
-    if (options.validateIssuer) {
-        log.info('We will validate issuer.');
-    }
+      // warn about validating the issuer
+    if (!options.validateIssuer) {
+      log.warn("We are not validating the issuer. This is fine if you are expecting multiple organizations to connect to your app. Otherwise you should validate the issuer.");
+  }
 
     // if you want to check JWT audience (aud), provide a value here
 

--- a/lib/passport-azure-ad/bearerstrategy.js
+++ b/lib/passport-azure-ad/bearerstrategy.js
@@ -26,8 +26,20 @@ Metadata = require('./metadata').Metadata,
 jws = require('jws');
 
 var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: OAuth Bearer Strategy'
+    name: 'Microsoft OpenID Connect: OAuth Bearer Strategy',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
 
 var PEMkey = null;
 /**
@@ -80,6 +92,8 @@ var PEMkey = null;
 function Strategy(options, verify) {
 /*jshint validthis: true */
 
+    // if logging level specified, switch to it.
+    if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
 
 if (options.policyName) {
 
@@ -117,7 +131,7 @@ if (options.policyName) {
     if (options.identityMetadata) {
 
         log.info('Metadata url provided to Strategy was: ', options.identityMetadata);
-        this.metadata = new Metadata(options.identityMetadata, "oidc");
+        this.metadata = new Metadata(options.identityMetadata, "oidc", options);
     }
 
     if (!options.certificate && !options.identityMetadata) {
@@ -211,7 +225,7 @@ if (options.policyName) {
     var opts = {};
     opts.passReqToCallback = true;
 
-    console.log('Req: ' + options.passReqToCallback);
+    
 
     BearerStrategy.call(this, options, jwtVerify);
 

--- a/lib/passport-azure-ad/logging.js
+++ b/lib/passport-azure-ad/logging.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var bunyan = require('bunyan');
+
+var getLogger = function(name) {
+
+var log = bunyan.createLogger({
+
+    name: name,
+     streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
+});
+  return log;
+};
+
+exports.getLogger = getLogger;

--- a/lib/passport-azure-ad/metadata.js
+++ b/lib/passport-azure-ad/metadata.js
@@ -29,16 +29,31 @@ var async = require('async');
 
 var bunyan = require('bunyan');
 var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: Passport Strategy: Metadata Parser'
+    name: 'Microsoft OpenID Connect: Passport Strategy: Metadata Parser',
+     streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
 
-var Metadata = function(url, authtype) {
+var Metadata = function(url, authtype, options) {
     if (!url) {
         throw new Error("Metadata: url is a required argument");
     }
     if (!authtype) {
         throw new Error('OIDCBearerStrategy requires an authentication type specified to metadata parser. Valid types are saml, wsfed, or odic"');
     }
+
+        // if logging level specified, switch to it.
+  if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
+
     this.url = url;
     this.metadata = null;
     this.authtype = authtype;

--- a/lib/passport-azure-ad/metadata.js
+++ b/lib/passport-azure-ad/metadata.js
@@ -24,24 +24,9 @@ var xml2js = require('xml2js');
 var request = require('request');
 var aadutils = require('./aadutils');
 var async = require('async');
+var Log = require('./logging').getLogger;
 
-// Logging
-
-var bunyan = require('bunyan');
-var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: Passport Strategy: Metadata Parser',
-     streams: [
-        {
-            stream: process.stderr,
-            level: "error",
-            name: "error"
-        }, 
-        {
-            stream: process.stdout,
-            level: "warn",
-            name: "console"
-        }, ]
-});
+var log = new Log("AzureAD: Metadata Parser");
 
 var Metadata = function(url, authtype, options) {
     if (!url) {
@@ -189,7 +174,7 @@ Metadata.prototype.updateOidcMetadata = function(doc, next) {
                     log.info("***********");*/
                     next(null);
                 } catch (e) {
-                    log.warn("No keys found at endpoint!");
+                    log.error("No keys found at endpoint!");
                     next(new Error(e));
                 }
             },
@@ -244,6 +229,7 @@ Metadata.prototype.fetch = function(callback) {
                 if (err) {
                     next(err);
                 } else if (response.statusCode !== 200) {
+                    log.error("Cannot get AAD Federation metadata from endpoint you specified", self.url);
                     next(new Error("Error:" + response.statusCode + " Cannot get AAD Federation metadata from " + self.url));
                 } else {
                     next(null, body);
@@ -268,6 +254,7 @@ Metadata.prototype.fetch = function(callback) {
                 next(null);
 
             } else {
+                log.error("No Authentication type specified to metadata parser. Valid types are saml, wsfed, or odic");
                 next(new Error("No Authentication type specified to metadata parser. Valid types are saml, wsfed, or odic"));
             }
 

--- a/lib/passport-azure-ad/oidcsetup.js
+++ b/lib/passport-azure-ad/oidcsetup.js
@@ -21,7 +21,18 @@ var configuration = require('./oidcconfig').configuration,
 bunyan = require('bunyan');
 
 var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Passport Strategy: Setup'
+    name: 'Microsoft OIDC Passport Strategy: Setup',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
 
 exports = module.exports = function(identifier, done) {

--- a/lib/passport-azure-ad/oidcsetup.js
+++ b/lib/passport-azure-ad/oidcsetup.js
@@ -18,22 +18,9 @@
  */
 
 var configuration = require('./oidcconfig').configuration,
-bunyan = require('bunyan');
+Log = require('./logging').getLogger;
 
-var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Passport Strategy: Setup',
-         streams: [
-        {
-            stream: process.stderr,
-            level: "error",
-            name: "error"
-        }, 
-        {
-            stream: process.stdout,
-            level: "warn",
-            name: "console"
-        }, ]
-});
+var log = new Log("AzureAD: OIDC Setup");
 
 exports = module.exports = function(identifier, done) {
   log.info('OpenID Discovery...');

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -28,27 +28,14 @@ var passport = require('passport'),
    OAuth2 = require('oauth').OAuth2,
    setup = require('./oidcsetup'),
    Validator = require('./validator').Validator,
-   bunyan = require('bunyan'),
+   Log = require('./logging').getLogger,
    InternalOAuthError = require('./errors/internaloautherror'),
    Metadata = require('./metadata').Metadata,
    async = require('async');
 
 var cacheManager = require('cache-manager');
 
-var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Passport Strategy',
-     streams: [
-        {
-            stream: process.stderr,
-            level: "error",
-            name: "error"
-        }, 
-        {
-            stream: process.stdout,
-            level: "warn",
-            name: "console"
-        }, ]
-});
+var log = new Log("AzureAD: OIDC Passport Strategy");
 
 var memoryCache = cacheManager.caching({store: 'memory', max: 3600, ttl: 1800/*seconds*/});
 var ttl = 1800; // 30 minutes cache
@@ -85,7 +72,11 @@ function Strategy(options, verify) {
     if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
 
 
+    // warn about validating the issuer
+    if (!options.validateIssuer) {
+      log.warn("We are not validating the issuer. This is fine if you are expecting multiple organizations to connect to your app. Otherwise you should validate the issuer.");
   }
+}
 
 
 /**
@@ -130,7 +121,7 @@ async.waterfall([
     log.info("");
 
     if (!self._options.tenantName) {
-        log.warn("For B2C you must specify a tenant name, none was presented to Strategy as required. (example: tenantName:contoso.onmicrosoft.com");
+        log.error("For B2C you must specify a tenant name, none was presented to Strategy as required. (example: tenantName:contoso.onmicrosoft.com");
         throw new TypeError('OIDCStrategy requires you specify a tenant name to Strategy if using a B2C tenant. (example: tenantName:contoso.onmicrosoft.com');
     }
 

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -36,7 +36,18 @@ var passport = require('passport'),
 var cacheManager = require('cache-manager');
 
 var log = bunyan.createLogger({
-    name: 'Microsoft OIDC Passport Strategy'
+    name: 'Microsoft OIDC Passport Strategy',
+     streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
 
 var memoryCache = cacheManager.caching({store: 'memory', max: 3600, ttl: 1800/*seconds*/});
@@ -66,12 +77,17 @@ function Strategy(options, verify) {
   this._passReqToCallback = !!options.passReqToCallback;
 
     if (!options.identityMetadata) {
-        log.warn("No options was presented to Strategy as required.");
+        log.error("No options was presented to Strategy as required.");
         throw new TypeError('OIDCStrategy requires either a PEM encoded public key or a metadata location that contains cert data for RSA and ECDSA callback.');
     }
 
+    // if logging level specified, switch to it.
+    if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
+
 
   }
+
+
 /**
  * Inherit from `passport.Strategy`.
  */
@@ -626,7 +642,7 @@ var self = this;
 
 
     memoryCache.wrap(self._cacheKey, function (cacheCallback) {
-    metadata = new Metadata(metadata, "oidc");
+    metadata = new Metadata(metadata, "oidc", options);
     metadata.fetch(function(err) {
         if (err) {
             return cacheCallback(new Error("Unable to fetch metadata: " + err));

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -63,6 +63,7 @@ function Strategy(options, verify) {
   this._configurers = [];
   this._cacheKey = 'ordinary';
   this._skipUserProfile = '';
+  this._passReqToCallback = !!options.passReqToCallback;
 
     if (!options.identityMetadata) {
         log.warn("No options was presented to Strategy as required.");
@@ -332,8 +333,11 @@ function(next) {
                 self._verify(req, iss, sub, profile, accessToken, refreshToken, verified);
               } else if (arity === 5) {
                 self._verify(req, iss, sub, profile, verified);
-              } else { // arity == 4
+              } else if (arity === 4) { 
                 self._verify(req, iss, sub, verified);
+              }
+              else { // default - just pass back a profile
+                self._verify(req, profile, verified);
               }
             } else {
               arity = self._verify.length;
@@ -345,8 +349,11 @@ function(next) {
                 self._verify(iss, sub, profile, accessToken, refreshToken, verified);
               } else if (arity === 4) {
                 self._verify(iss, sub, profile, verified);
-              } else { // arity == 3
+              } else if (arity === 3) { 
                 self._verify(iss, sub, verified);
+              }
+              else { // default - just pass back a profile
+                self._verify(profile, verified);
               }
             }
           }
@@ -465,8 +472,11 @@ function(next) {
                 self._verify(req, iss, sub, profile, accessToken, refreshToken, verified);
               } else if (arity === 5) {
                 self._verify(req, iss, sub, profile, verified);
-              } else { // arity == 4
+              } else if (arity === 4) { 
                 self._verify(req, iss, sub, verified);
+              }
+              else { // default - just pass back a profile
+                self._verify(req, profile, verified);
               }
             } else {
               arity = self._verify.length;
@@ -478,8 +488,11 @@ function(next) {
                 self._verify(iss, sub, profile, accessToken, refreshToken, verified);
               } else if (arity === 4) {
                 self._verify(iss, sub, profile, verified);
-              } else { // arity == 3
+              } else if (arity === 3) { 
                 self._verify(iss, sub, verified);
+              }
+              else { // default - just pass back a profile
+                self._verify(profile, verified);
               }
             }
           }

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -546,12 +546,13 @@ log.info("Going in with our config loaded as: ", config);
 
 
       // Add support for automatically generating a random state for verification.
-      // Make state optional, if `config` disables it and supplies an alternative
-      //       session key.
-      //var state = options.state;
-      //if (state) { params.state = state; }
+      
+      var state;
 
-      // var state = utils.uid(16); no longer used in OpenID Connect flows.
+      if (!options.state) { state = utils.uid(16); } 
+
+      params.state = state; 
+
       var location;
 
       // Implement support for standard OpenID Connect params (display, prompt, etc.)

--- a/lib/passport-azure-ad/saml.js
+++ b/lib/passport-azure-ad/saml.js
@@ -57,7 +57,7 @@ var SAML = function(options) {
     var checker = new Validator(config);
     checker.validate(options);
     this.options = this.initialize(options);
-    this.metadata = new Metadata(options.identityMetadata, "saml");
+    this.metadata = new Metadata(options.identityMetadata, "saml", options);
     this.federationMetadata = null;
 };
 

--- a/lib/passport-azure-ad/tokenValidator.js
+++ b/lib/passport-azure-ad/tokenValidator.js
@@ -24,26 +24,11 @@
 var jwt = require('jsonwebtoken');
 var jws = require('jws');
 var aadutils = require('./aadutils');
+var Log = require('./logging');
 var PEMkey;
 
 // Logging
-
-var bunyan = require('bunyan');
-var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: Passport Strategy: Token Validator',
-         streams: [
-        {
-            stream: process.stderr,
-            level: "error",
-            name: "error"
-        }, 
-        {
-            stream: process.stdout,
-            level: "warn",
-            name: "console"
-        }, ]
-});
-
+var log = new Log("AzureAD: Token Validation");
 
 var TokenValidator = function(metadata, options) {
     if (!metadata) {

--- a/lib/passport-azure-ad/tokenValidator.js
+++ b/lib/passport-azure-ad/tokenValidator.js
@@ -30,8 +30,20 @@ var PEMkey;
 
 var bunyan = require('bunyan');
 var log = bunyan.createLogger({
-    name: 'Microsoft OpenID Connect: Passport Strategy: Token Validator'
+    name: 'Microsoft OpenID Connect: Passport Strategy: Token Validator',
+         streams: [
+        {
+            stream: process.stderr,
+            level: "error",
+            name: "error"
+        }, 
+        {
+            stream: process.stdout,
+            level: "warn",
+            name: "console"
+        }, ]
 });
+
 
 var TokenValidator = function(metadata, options) {
     if (!metadata) {
@@ -42,6 +54,9 @@ var TokenValidator = function(metadata, options) {
     }
     this.metadata = metadata;
     this.options = options;
+
+    // if logging level specified, switch to it.
+    if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
 };
 
 

--- a/lib/passport-azure-ad/wsfedstrategy.js
+++ b/lib/passport-azure-ad/wsfedstrategy.js
@@ -102,7 +102,7 @@ function Strategy(options, verify) {
 
     // Create the metadata object if the user has specified a federation metadata url
     if (options.identityMetadata) {
-        this.metadata = new Metadata(options.identityMetadata, 'wsfed');
+        this.metadata = new Metadata(options.identityMetadata, 'wsfed', options);
         this.identityProviderUrl = null;
     } else {
         if (!options.cert) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,7 @@
 {
   "name": "passport-azure-ad",
   "version": "1.3.6",
-  "licenses": [
-    {
-      "type": "Apache 2.0",
-      "url": "https://github.com/MSOpenTech/aal/raw/master/License.txt"
-    }
-  ],
+ "license" : "MIT",
   "keywords": [
     "saml",
     "samlp",

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -42,6 +42,7 @@ var Metadata = require('../lib/passport-azure-ad/metadata').Metadata;
 var metadataUrl = 'https://login.windows.net/GraphDir1.OnMicrosoft.com/federationmetadata/2007-06/federationmetadata.xml';
 var oidcMetadataUrl = 'https://login.microsoftonline.com/common/.well-known/openid-configuration';
 var oidcMetadataUrl2 = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
+var options = {};
 
 exports['metadata'] = {
 
@@ -51,7 +52,7 @@ exports['metadata'] = {
 
         test.doesNotThrow(
             function() {
-                new Metadata('http://foo.com/federationmetadata.xml', 'wsfed');
+                new Metadata('http://foo.com/federationmetadata.xml', 'wsfed', options);
             },
             Error,
             'Should not fail with url present'
@@ -79,10 +80,24 @@ exports['metadata'] = {
 
         test.throws(
             function() {
-                new Metadata('http://foo.com/federationmetadata.xml');
+                new Metadata('http://foo.com/federationmetadata.xml', options);
             },
             Error,
             'Should fail with auth type missing'
+        );
+
+        test.done();
+    },
+        'missing option options': function(test) {
+        test.expect(1);
+        // tests here
+
+        test.throws(
+            function() {
+                new Metadata('http://foo.com/federationmetadata.xml', 'wsfed');
+            },
+            Error,
+            'Should fail with options missing'
         );
 
         test.done();
@@ -93,7 +108,7 @@ exports['metadata'] = {
 
         test.doesNotThrow(
             function() {
-                var m = new Metadata(metadataUrl, 'saml');
+                var m = new Metadata(metadataUrl, 'saml', options);
                 m.fetch(function(err) {
                     test.ifError(err);
                     test.ok(m.saml.certs.length > 0, 'fetch should obtain 1 or more saml x509 certificates');
@@ -105,6 +120,7 @@ exports['metadata'] = {
             Error,
             'Should not fail with url present and auth type saml'
         );
+
     },
     'fetch metadata wsfed': function(test) {
         test.expect(4);
@@ -112,7 +128,7 @@ exports['metadata'] = {
 
         test.doesNotThrow(
             function() {
-                var m = new Metadata(metadataUrl, 'wsfed');
+                var m = new Metadata(metadataUrl, 'wsfed', options);
                 m.fetch(function(err) {
                     test.ifError(err);
                     test.ok(m.wsfed.certs.length > 0, 'fetch should obtain 1 or more wsfed x509 certificates');
@@ -123,6 +139,7 @@ exports['metadata'] = {
             Error,
             'Should not fail with url present and auth type wsfed'
         );
+
     },
     'fetch metadata oidc': function(test) {
         test.expect(4);
@@ -130,7 +147,7 @@ exports['metadata'] = {
 
         test.doesNotThrow(
             function() {
-                var m = new Metadata(oidcMetadataUrl, 'oidc');
+                var m = new Metadata(oidcMetadataUrl, 'oidc', options);
                 m.fetch(function(err) {
                     test.ifError(err);
                     test.ok(m.oidc.algorithms, 'fetch algorithms');
@@ -141,6 +158,7 @@ exports['metadata'] = {
             Error,
             'Should not fail with url present and auth type oidc'
         );
+
     },
         'fetch metadata oidc v2': function(test) {
         test.expect(4);
@@ -148,7 +166,7 @@ exports['metadata'] = {
 
         test.doesNotThrow(
             function() {
-                var m = new Metadata(oidcMetadataUrl2, 'oidc');
+                var m = new Metadata(oidcMetadataUrl2, 'oidc', options);
                 m.fetch(function(err) {
                     test.ifError(err);
                     test.ok(m.oidc.algorithms, 'fetch algorithms');
@@ -159,5 +177,6 @@ exports['metadata'] = {
             Error,
             'Should not fail with url present and auth type oidc'
         );
+
     }
 };


### PR DESCRIPTION
Logging is now much quieter and allows for future plugging in of other logger if required.
Details:
* The logging now defaults to an ERROR level logging to stderr no matter what
* The logging now defaults to WARN level logging for everything else, but this can be overridden by a setting passed in to the Strategy if desired
* This is only for ODIC and Bearer as WS-Fed and SAML are out of support (but anyone is welcome to add it in, should be minimal)

