### PR TITLE
Adjusted null `this.certs` in checkSignature

### DIFF
--- a/lib/passport-azure-ad/saml.js
+++ b/lib/passport-azure-ad/saml.js
@@ -318,7 +318,7 @@ SAML.prototype.checkSignature = function(xml, next) {
   var validSignature = false;
 
   // Verify signature
-  for (var i=0;i<this.certs.length;i++) {
+  for (var i=0;i<self.metadata.saml.certs.length;i++) {
     if (self.validateSignature(xml, self.metadata.saml.certs[i])) {
       validSignature = true;
       break;

--- a/lib/passport-azure-ad/samlutils.js
+++ b/lib/passport-azure-ad/samlutils.js
@@ -107,11 +107,15 @@ exports.getProfile = function(assertion) {
 
   if (attributes) {
     attributes.forEach(function(attribute) {
-      var value = aadutils.getFirstElement(attribute, 'AttributeValue');
-      if (typeof value === 'string') {
-        profile[attribute.$.Name] = value;
+      if (attribute.AttributeValue && attribute.AttributeValue.length > 1) {
+        profile[attribute.$.Name] = attribute.AttributeValue;
       } else {
-        profile[attribute.$.Name] = value._;
+        var value = aadutils.getFirstElement(attribute, 'AttributeValue');
+        if (typeof value === 'string') {
+          profile[attribute.$.Name] = value;
+        } else {
+          profile[attribute.$.Name] = value._;
+        }
       }
     });
   }


### PR DESCRIPTION
I found the same behavior as issue (https://github.com/AzureAD/passport-azure-ad/issues/70).

That being said I made the change and submitted a pull-request.

Kudos to @fredrikj