### PR TITLE
fix - read state from options if it is set

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -573,7 +573,8 @@ log.info("Going in with our config loaded as: ", config);
       
       var state;
 
-      if (!options.state) { state = utils.uid(16); } 
+      if (!options.state) { state = utils.uid(16); }
+      else { state = options.state; }
 
       params.state = state; 
 


### PR DESCRIPTION
Hey
I've noticed that although I've set the state parameter it was not sent to azure ad in authorize request. I've fixed the bug.
Thanks,
Omer