### PR TITLE
Add Prompt to Config

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -562,6 +562,9 @@ log.info("Going in with our config loaded as: ", config);
       }
       if (config.resourceURL) {
       params['resource'] = config.resourceURL; 
+      //Allow developer to decide prompt login Policy
+      if(config.prompt != undefined){
+        params.prompt = config.prompt;
       }
 
 
@@ -628,6 +631,7 @@ var self = this;
 // 
  async.waterfall([
           
+
             // fetch the metadata
     function loadMetadata(next) {
 
@@ -730,7 +734,6 @@ log.info("Setting options");
 
   next(null, options);
 
-},        
 ], function(err) {
             done(err, options);
         });

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -562,9 +562,6 @@ log.info("Going in with our config loaded as: ", config);
       }
       if (config.resourceURL) {
       params['resource'] = config.resourceURL; 
-      //Allow developer to decide prompt login Policy
-      if(config.prompt != undefined){
-        params.prompt = config.prompt;
       }
 
 
@@ -631,7 +628,6 @@ var self = this;
 // 
  async.waterfall([
           
-
             // fetch the metadata
     function loadMetadata(next) {
 
@@ -734,6 +730,7 @@ log.info("Setting options");
 
   next(null, options);
 
+},        
 ], function(err) {
             done(err, options);
         });

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -562,6 +562,9 @@ log.info("Going in with our config loaded as: ", config);
       }
       if (config.resourceURL) {
       params['resource'] = config.resourceURL; 
+      //Allow developer to decide prompt login Policy
+      if(config.prompt != undefined){
+        params.prompt = config.prompt;
       }
 
 

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -561,7 +561,8 @@ log.info("Going in with our config loaded as: ", config);
         params.scope = 'openid';
       }
       if (config.resourceURL) {
-      params['resource'] = config.resourceURL; 
+      params['resource'] = config.resourceURL;
+      }
       //Allow developer to decide prompt login Policy
       if(config.prompt != undefined){
         params.prompt = config.prompt;


### PR DESCRIPTION
This allows for developers to require users to input credentials upon logging in everytime. Without this users must clear their cookies on login.microsoft.com in order to switch users on a web app using this strategy for authentication.

https://msdn.microsoft.com/en-us/library/azure/dn645542.aspx#code-snippet-3