### PR TITLE
add scopeSeparator option

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -66,7 +66,6 @@ function Strategy(options, verify) {
   this._cacheKey = 'ordinary';
   this._skipUserProfile = '';
   this._passReqToCallback = !!options.passReqToCallback;
-  this._scopeSeparator = options.scopeSeparator || ' ';
 
     if (!options.identityMetadata) {
         log.error("No options was presented to Strategy as required.");
@@ -555,7 +554,7 @@ log.info("Going in with our config loaded as: ", config);
       log.info('We are sending the response_mode: ', params['response_mode']);
       params['nonce'] = utils.uid(16);
       var scope = config.scope;
-      if (Array.isArray(scope)) { scope = scope.join(self._scopeSeparator); }
+      if (Array.isArray(scope)) { scope = scope.join(config.scopeSeparator); }
       if (scope) {
         params.scope = 'openid' + config.scopeSeparator + scope;
       } else {

--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -66,6 +66,7 @@ function Strategy(options, verify) {
   this._cacheKey = 'ordinary';
   this._skipUserProfile = '';
   this._passReqToCallback = !!options.passReqToCallback;
+  this._scopeSeparator = options.scopeSeparator || ' ';
 
     if (!options.identityMetadata) {
         log.error("No options was presented to Strategy as required.");


### PR DESCRIPTION
scopeSeparator is used later in the `authenticate` method of this strategy. Looks like there was some code copied from `passport-oauth2` while this strategy inherits from `passport-strategy` instead.
Without a default, auth requests fail when providing additional scopes as Array. Even if a `scopeSeparator` option was provided, it wasn't respected anyway