### PR TITLE
Enabled setting msafed query parameter.

### DIFF
--- a/lib/passport-azure-ad/oidcstrategy.js
+++ b/lib/passport-azure-ad/oidcstrategy.js
@@ -561,9 +561,12 @@ log.info("Going in with our config loaded as: ", config);
         params.scope = 'openid';
       }
       if (config.resourceURL) {
-      params['resource'] = config.resourceURL; 
+        params['resource'] = config.resourceURL; 
       }
 
+      if (config.msafed !== undefined) {
+        params['msafed'] = config.msafed;
+      }
 
 
       //if (policy) { params['p'] = policy; }; // Policy parameter should be included.
@@ -662,6 +665,7 @@ log.info("Setting options");
   options.responseType = options.responseType;
   options.responseMode = options.responseMode;
   options.resourceURL = options.resourceURL;
+  options.msafed = options.msafed;
 
 
 
@@ -678,7 +682,6 @@ log.info("Setting options");
   options.clientID = options.clientID;
   options.clientSecret = options.clientSecret;
   options.callbackURL = options.callbackURL;
-
 
   // Now that we have our options for configuration, let's check them for issues.
 
@@ -723,7 +726,8 @@ log.info("Setting options");
         scope: options.scope,
         scopeSeparator: options.scopeSeparator,
         identifierField: options.identifierField,
-        resourceURL: options.resourceURL
+        resourceURL: options.resourceURL,
+        msafed: options.msafed
 
       });
     });


### PR DESCRIPTION
Added an option to OIDC strategy that allows setting the msafed query
parameter on all oauth requests. The parameter allows users of
passport-azure-ad to only authenticate enterprise users.