### PR TITLE
fix BearerStrategy.call _extend leaving out req. fixes #112

### DIFF
--- a/lib/bearerstrategy.js
+++ b/lib/bearerstrategy.js
@@ -185,7 +185,7 @@ function Strategy(options, verifyFn) {
 
   // force passReqToCallback to be `true` for our decoding verify wrapper
   /* eslint-disable no-underscore-dangle */
-  BearerStrategy.call(this, util._extend({}, opts, { passReqToCallback: true }), jwtVerify);
+  BearerStrategy.call(this, util._extend(opts, { passReqToCallback: true }), jwtVerify);
   /* eslint-enable no-underscore-dangle */
 
   this.name = 'oauth-bearer'; // Me, a name I call myself.


### PR DESCRIPTION
Since opts is initialized at the top of the function to either an empty object or the options variable and the code afterwards assumes it will be an object and modifies its properties we can remove the need to extend the opts into an empty object in the BearerStrategy.call and just combine opts with passReqToCallback

util._extend does not accept more than 2 arguments so currently passReqToCallback is dropped and not forced true unless you set it in your config of your own app

see: https://github.com/defunctzombie/node-util/blob/master/util.js#L572