### PR TITLE
fix whitespacing issue in rsaPublicKeyPem in aadutils.js fixes #117

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -142,21 +142,21 @@ exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
 
   const encodedModlen = encodeLengthHex(modlen);
   const encodedExplen = encodeLengthHex(explen);
-  const encodedPubkey = `30
-    ${encodeLengthHex(
-          modlen +
-          explen +
-          encodedModlen.length / 2 +
-          encodedExplen.length / 2 + 2
-        )}
-    02${encodedModlen}${modulusHex}
-    02${encodedExplen}${exponentHex}`;
+  const encodedPubkey = '30' +
+        encodeLengthHex(
+            modlen +
+            explen +
+            encodedModlen.length / 2 +
+            encodedExplen.length / 2 + 2
+        ) +
+        '02' + encodedModlen + modulusHex +
+        '02' + encodedExplen + exponentHex;
 
   const derB64 = new Buffer(encodedPubkey, 'hex').toString('base64');
 
-  const pem = `-----BEGIN RSA PUBLIC KEY-----\n
-    ${derB64.match(/.{1,64}/g).join('\n')}
-    \n-----END RSA PUBLIC KEY-----\n`;
+  let pem = `-----BEGIN RSA PUBLIC KEY-----\n`;
+  pem += `${derB64.match(/.{1,64}/g).join('\n')}`
+  pem += `\n-----END RSA PUBLIC KEY-----\n`;
 
   return pem;
 };


### PR DESCRIPTION
Whitespace is being added to the pem cert as a result of how the ES6 template string is written on multiple lines in rsaPublicKeyPem() in aadutils.js. fixes #117. this causes the buffer.js and/or crypto library verify function to fail with `TypeError: Invalid hex string` until `encodedPubkey` is converted and then failing with `Error: PEM_read_bio_PUBKEY failed` until `pem` is fixed.