### PR TITLE
Solved issue 121: regex error in pem.js

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -28,9 +28,24 @@
  * openssl req -x509 -nodes -days 365 -newkey rsa:2048 -sha1 -keyout private.pem -out public.pem
  */
 
+
+/*
+ * certificate string and private key string have the following format:
+ * 1. certificate string:
+ *    "-----BEGIN CERTIFICATE----- content ----END CERTIFICATE-----"
+ * 2. private key string:
+ *    "-----BEGIN PRIVATE KEY----- content -----END PRIVATE KEY-----"
+ *
+ * We define two regex (CERT_REGEX and PRIVATE_KEY_REGEX), in which the content 
+ * we are interested in is captured as a (and the only) capture group. We can 
+ * then use the getFirstCapturingGroup function below to get the content, and 
+ * use the removeRN function below to sanitize the content by removing the \r 
+ * and \n's in the content.
+ */
+
 /* eslint-disable max-len */
-const CERT_REGEX = /-+BEGIN\s+.*CERTIFICATE[^-]*-+(?:\s)+([a-zA-Z0-9+\/=\r\n]+)-+END\s+.*CERTIFICATE[^-]*-+/;
-const PRIVATE_KEY_REGEX = /-+BEGIN\s+.*PRIVATE\s+.*KEY[^-]*-+(?:\s)+([a-zA-Z0-9+\/=\r\n]+)-+END\s+.*PRIVATE\s+.*KEY[^-]*-+/;
+const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
+const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
 /* eslint-enable max-len */
 
 function getFirstCapturingGroup(str, regex) {
@@ -38,10 +53,15 @@ function getFirstCapturingGroup(str, regex) {
     throw new Error(`'str' must be of type "String", actually is ${typeof str}`);
   }
   const matches = str.match(regex);
-  if (!Array.isArray(matches) || matches.length !== 1) {
+  // if str matches the regex (either CERT_REGEX or PRIVATE_KEY_REGEX), then
+  // matches will always have two groups:
+  // matches[0]: this is always the entire match, in this case, the certificate/key str 
+  // matches[1]: this is the first (and the only) group we want to capture in the regex,
+  // which is the certifcate/key content
+  if (!Array.isArray(matches) || matches.length !== 2) {
     return null;
   }
-  return matches[0];
+  return matches[1];
 }
 
 function removeRN(str) {


### PR DESCRIPTION
If there is a match, str.match(regex) always returns at least one group, where
the first group is always the entire match, and the rest are the capturing groups.
Therefore getFirstCapturingGroup returns an array of two groups, and the second
one is the content captured.

Also added some comments on top of pem.js.