### PR TITLE
Added state check, err msg details, comments on strategy

### DIFF
--- a/lib/errors/internaloautherror.js
+++ b/lib/errors/internaloautherror.js
@@ -13,6 +13,14 @@ function InternalOAuthError(message, err) {
   Error.call(this);
   Error.captureStackTrace(this, InternalOAuthError);
   this.name = 'InternalOAuthError';
+  if (err && err.data) {
+    try {
+      let errlist = JSON.parse(err.data);
+      message += '\nerror: \n' + errlist['error'] + '\nerror_message: \n' + errlist['error_message']; 
+    } catch(ex) {
+      message += '\ndata: \n' + err.data;      
+    }
+  }
   this.message = message;
   this.oauthError = err;
 }

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -47,6 +47,10 @@ const Metadata = require('./metadata').Metadata;
 // global variable definitions
 const log = new Log('AzureAD: OIDC Passport Strategy');
 
+// save the state used in authentication request here, so we can compare it with
+// the returning state from the response
+var saved_state = null;
+
 const memoryCache = cacheManager.caching({ store: 'memory', max: 3600, ttl: 1800 /* seconds */ });
 const ttl = 1800; // 30 minutes cache
 // Note: callback is optional in set() and del().
@@ -119,13 +123,21 @@ function onProfileLoaded(strategy, args) {
  */
 function Strategy(options, verify) {
   passport.Strategy.call(this);
+
+  /*
+   *  Caution when you want to change these values in the member functions of
+   *  Strategy, don't use `this`, since `this` points to a subclass of `Strategy`.
+   *  To get `Strategy`, use Object.getPrototypeOf(this).
+   *  
+   *  More comments at the beginning of `Strategy.prototype.authenticate`. 
+   */
   this._options = options;
   this.name = 'azuread-openidconnect';
   this._verify = verify;
   this._configurers = [];
-  this._cacheKey = 'ordinary';
   this._skipUserProfile = !!options.skipUserProfile;
   this._passReqToCallback = !!options.passReqToCallback;
+
 
   if (!options.identityMetadata) {
     // default value should be https://login.microsoftonline.com/common/.well-known/openid-configuration
@@ -156,7 +168,54 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
+  /* 
+   * We should be careful using 'this'. Avoid the usage like `this.xxx = ...`
+   * unless you know what you are doing.
+   *
+   * In the passport source code 
+   * (https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js)
+   * when it attempts to call the `oidcstrategy.authenticate` function, passport
+   * creates an instance inherting oidcstrategy and then calls `instance.authenticate`.  
+   * Therefore, when we come here, `this` is the instance, its prototype is the
+   * actual oidcstrategy, i.e. the `Strategy`. This means:
+   * (1) `this._options = `, `this._verify = `, etc only adds new fields to the
+   *      instance, it doesn't change the values in oidcstrategy, i.e. `Strategy`. 
+   * (2) `this._options`, `this._verify`, etc returns the field in the instance,
+   *     and if there is none, returns the field in oidcstrategy, i.e. `strategy`.
+   * (3) each time we call `authenticate`, we will get a brand new instance
+   *
+   * Therefore, doing `this.xxx = ...` here doesn't make much sense.
+   * 
+   * If you want to change the values in `Strategy`, use 
+   *      const oidcstrategy = Object.getPrototypeOf(self);
+   * to get the strategy first.
+   *
+   * If you want to save some variable from one use of `authenticate` and use it
+   * in later use of `authenticate`, there are two ways:
+   * (1) add a member in Strategy, and access it using the prototype of `this`
+   * (2) make it a global variable
+   * One example would be the `state`, which we used the 2nd way and made it global.
+   * 
+   * Note: Simply do `const self = Object.getPrototypeOf(this)` and use `self`
+   * won't work, since the `this` instance has a couple of functions like
+   * success/fail/error... which `authenticate` will call. The following is the
+   * structure of `this`:
+   *
+   *   this
+   *   | --  success:  function(user, info)
+   *   | --  fail:     function(challenge, status)
+   *   | --  redirect: function(url, status)
+   *   | --  pass:     function()
+   *   | --  __proto__:  Strategy
+   *                 | --  _verify
+   *                 | --  _options
+   *                 | --  ...
+   *                 | --  __proto__:
+   *                              | --  authenticate:  function(req, options)
+   *                              | --  ...
+   */ 
   const self = this;
+
 
   // Allow for some overrides that may come in to the authenticate strategy.
   //
@@ -175,6 +234,10 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
       (next) => {
         // B2C interception
         let metadata = self._options.identityMetadata;
+
+        // use 'ordinary' as the default cachekey, in the case of B2C, we will
+        // change the value to policy later
+        let cachekey = 'ordinary';
 
         // We listen for the p paramter in any response and set it. If it has been set already and in memory (profile) we skip this as it's not necessary to set again.
         // @TODO when forceB2C is set but no req.query.p is present, the policy variable would be 'undefined'
@@ -197,16 +260,16 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
             .replace('common', self._options.tenantName)
             .concat(`?p=${policy}`);
 
-          self._cacheKey = policy; // this policy will become cache key.
+          cachekey = policy; // this policy will become cache key.
 
           log.info('B2C: New Metadata url provided to Strategy was: ', metadata);
         }
 
-        return next(null, metadata);
+        return next(null, metadata, cachekey);
       },
       // load options from metadata url
-      (metadata, next) => {
-        self.setOptions(self._options, metadata, next);
+      (metadata, cachekey, next) => {
+        self.setOptions(self._options, metadata, cachekey, next);
       },
       // handle error response
       (next) => {
@@ -234,7 +297,16 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
           return next();
         }
         const code = (req.query && req.query.code) ? req.query.code : req.body.code;
+        const state = (req.query && req.query.code) ? req.query.state : req.body.state;
 
+        // check state
+        if (!state || state !== saved_state)
+          return next(new Error('state mismatch in the flow of obtaining `code`, state sent: ' + saved_state +
+                                  " state received: " + state));
+        // clear the saved state
+        saved_state = null;
+
+        // check code
         if (!code) {
           return next(new Error('Failed to extract `code` from request object'));
         }
@@ -383,6 +455,13 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
           Assumed because no auth code was in the query and we are POST.`);
         log.info('Body received was: ', req.body);
 
+        // check state
+        if (!req.body.state || req.body.state !== saved_state)
+          return next(new Error("state mismatch in the flow of obtaining `id_token`, state sent: " + saved_state +
+                                  " state received: " + req.body.state));
+        // clear the saved state
+        saved_state = null;
+
         // We are not doing auth code so we set the tokens to null
         const accessToken = null;
         const refreshToken = null;
@@ -506,13 +585,11 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 
           // if (policy) { params['p'] = policy; }; // Policy parameter should be included.
 
-          // Add support for automatically generating a random state for verification.
-
-          let state;
-
-          if (!options.state) { state = utils.uid(16); } else { state = options.state; }
-
-          params.state = state;
+          // Add an automatically generated state to params, and remember it.
+          // Later when we get the id_token or authorization code back, we can 
+          // verify the state we sent are the same as the state returned in the
+          // query or body.
+          saved_state = params.state = utils.uid(16);
 
           let location;
 
@@ -548,7 +625,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
  * @param {Object} options
  * @return {Object} options
  */
-Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) {
+Strategy.prototype.setOptions = function setOptions(options, metadataUrl, cachekey, done) {
   const self = this;
 
   // Loading metadata from endpoint.
@@ -557,7 +634,7 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) 
     function loadMetadata(next) {
       log.info('Parsing Metadata: ', metadataUrl);
 
-      memoryCache.wrap(self._cacheKey, (cacheCallback) => {
+      memoryCache.wrap(cachekey, (cacheCallback) => {
         const metadata = new Metadata(metadataUrl, 'oidc', options);
         metadata.fetch((fetchMetadataError) => {
           if (fetchMetadataError) {
@@ -570,8 +647,6 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) 
     // merge fetched metadata with options
     function loadOptions(metadata, next) {
       // fetched metadata always takes precendence over configured options
-
-      self._skipUserProfile = !!options.skipUserProfile;
 
       // use default values where no option is present
       const opts = {


### PR DESCRIPTION
(Solved) Issue #111 
(Part-Fix) Issue #104 

1. added the state check
2. more details in the error message of internal oauth error
3. removed _cachekey field in strategy, and modified code accordingly
4. removed the duplicate assignment of _skipUserProfile
5. added comments on how to use `this`