### PR TITLE
key id check condition fixed

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -183,7 +183,7 @@ Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
     log.info('working on key:', key);
 
     // are we working on the right key?
-    if (!key.kid === kid) {
+    if (key.kid !== kid) {
       return false;
     }
 


### PR DESCRIPTION
"!keys.kid===kid" is "(!keys.kid) === kid", which condition always yields false. Therefore this bug causes us to always use the first key even the kid doesn't match, and that leads to token validation error. It should be "keys.kid !== kid".