### PR TITLE
key id check condition fixed

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -142,21 +142,16 @@ exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
 
   const encodedModlen = encodeLengthHex(modlen);
   const encodedExplen = encodeLengthHex(explen);
-  const encodedPubkey = `30
-    ${encodeLengthHex(
+  const encodedPubkey = `30${encodeLengthHex(
           modlen +
           explen +
           encodedModlen.length / 2 +
           encodedExplen.length / 2 + 2
-        )}
-    02${encodedModlen}${modulusHex}
-    02${encodedExplen}${exponentHex}`;
+        )}02${encodedModlen}${modulusHex}02${encodedExplen}${exponentHex}`;
 
   const derB64 = new Buffer(encodedPubkey, 'hex').toString('base64');
 
-  const pem = `-----BEGIN RSA PUBLIC KEY-----\n
-    ${derB64.match(/.{1,64}/g).join('\n')}
-    \n-----END RSA PUBLIC KEY-----\n`;
+  const pem = `-----BEGIN RSA PUBLIC KEY-----\n${derB64.match(/.{1,64}/g).join('\n')}\n-----END RSA PUBLIC KEY-----\n`;
 
   return pem;
 };

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -176,8 +176,12 @@ Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
   let pubKey = null;
   let foundKey = false;
 
-  if (!(kid && keys)) {
-    throw new Error('keys or kid is missing');
+  if (!kid) {
+    throw new Error('kid is missing');
+  }
+
+  if (!keys) {
+    throw new Error('keys is missing');
   }
 
   keys.some((key) => {
@@ -206,11 +210,13 @@ Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
 
     pubKey = aadutils.rsaPublicKeyPem(modulus, exponent);
     foundKey = true;
-    return true;
+    
+    return pubKey;
   });
 
   if (!foundKey)
     throw new Error(`a key with kid %s cannot be found`, kid);
+
   if (!pubKey)
     throw new Error(`generating public key pem failed for kid: %s`, kid);
 

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -174,16 +174,17 @@ Metadata.prototype.updateOidcMetadata = function updateOidcMetadata(doc, next) {
 Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
   const keys = this && this.oidc && Array.isArray(this.oidc.keys) ? this.oidc.keys : null;
   let pubKey = null;
+  let foundKey = false;
 
   if (!(kid && keys)) {
-    return null;
+    throw new Error('keys or kid is missing');
   }
 
   keys.some((key) => {
     log.info('working on key:', key);
 
     // are we working on the right key?
-    if (!key.kid === kid) {
+    if (key.kid !== kid) {
       return false;
     }
 
@@ -204,8 +205,14 @@ Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
     const exponent = new Buffer(key.e, 'base64');
 
     pubKey = aadutils.rsaPublicKeyPem(modulus, exponent);
-    return pubKey;
+    foundKey = true;
+    return true;
   });
+
+  if (!foundKey)
+    throw new Error(`a key with kid %s cannot be found`, kid);
+  if (!pubKey)
+    throw new Error(`generating public key pem failed for kid: %s`, kid);
 
   return pubKey;
 };

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -187,17 +187,21 @@ exports.metadata = {
     test.expect(5);
 
     const m = new Metadata('www.example.com', 'oidc', {});
+
     // example public keys from AAD
+
     var key1 = {
       e: "AQAB", 
       kid: "MnC_VZcATfM5pOYiJHMba9goEKY", 
       n: "vIqz-4-ER_vNWLON9yv8hIYV737JQ6rCl6XfzOC628seYUPf0TaGk91CFxefhzh23V9Tkq-RtwN1Vs_z57hO82kkzL-cQHZX3bMJD-GEGOKXCEXURN7VMyZWMAuzQoW9vFb1k3cR1RW_EW_P-C8bb2dCGXhBYqPfHyimvz2WarXhntPSbM5XyS5v5yCw5T_Vuwqqsio3V8wooWGMpp61y12NhN8bNVDQAkDPNu2DT9DXB1g0CeFINp_KAS_qQ2Kq6TSvRHJqxRR68RezYtje9KAqwqx4jxlmVAQy0T3-T-IAbsk1wRtWDndhO6s1Os-dck5TzyZ_dNOhfXgelixLUQ"
     };
+
     var key2 = {
       e: "AQAB",
       kid: "YbRAQRYcE_motWVJKHrwLBbd_9s",
       n: "vbcFrj193Gm6zeo5e2_y54Jx49sIgScv-2JO-n6NxNqQaKVnMkHcz-S1j2FfpFngotwGMzZIKVCY1SK8SKZMFfRTU3wvToZITwf3W1Qq6n-h-abqpyJTaqIcfhA0d6kEAM5NsQAKhfvw7fre1QicmU9LWVWUYAayLmiRX6o3tktJq6H58pUzTtx_D0Dprnx6z5sW-uiMipLXbrgYmOez7htokJVgDg8w-yDFCxZNo7KVueUkLkxhNjYGkGfnt18s7ZW036WoTmdaQmW4CChf_o4TLE5VyGpYWm7I_-nV95BBvwlzokVVKzveKf3l5UU3c6PkGy-BB3E_ChqFm6sPWw"
     };
+
     var correctPemKey2 = "-----BEGIN RSA PUBLIC KEY-----\n" + 
                      "MIIBCgKCAQEAvbcFrj193Gm6zeo5e2/y54Jx49sIgScv+2JO+n6NxNqQaKVnMkHc\n" +
                      "z+S1j2FfpFngotwGMzZIKVCY1SK8SKZMFfRTU3wvToZITwf3W1Qq6n+h+abqpyJT\n" +
@@ -206,6 +210,7 @@ exports.metadata = {
                      "NjYGkGfnt18s7ZW036WoTmdaQmW4CChf/o4TLE5VyGpYWm7I/+nV95BBvwlzokVV\n" +
                      "KzveKf3l5UU3c6PkGy+BB3E/ChqFm6sPWwIDAQAB\n" + 
                      "-----END RSA PUBLIC KEY-----\n";
+
     m.oidc = {keys: [key1, key2]};
 
     test.doesNotThrow(
@@ -232,7 +237,7 @@ exports.metadata = {
         var pem = m.generateOidcPEM(null);
       },
       Error,
-      "Should fail with 'keys or kid is missing'"
+      "Should fail with 'kid is missing'"
     );
 
     test.throws(
@@ -242,7 +247,7 @@ exports.metadata = {
         var pem = m.generateOidcPEM(key2.kid);
       },
       Error,
-      "Should fail with 'keys or kid is missing'"
+      "Should fail with 'keys is missing'"
     );
 
     test.done();

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -183,4 +183,68 @@ exports.metadata = {
       'Should not fail with url present and auth type oidc'
     );
   },
+  'check keys and pem generation': (test) => {
+    test.expect(5);
+
+    const m = new Metadata('www.example.com', 'oidc', {});
+    // example public keys from AAD
+    var key1 = {
+      e: "AQAB", 
+      kid: "MnC_VZcATfM5pOYiJHMba9goEKY", 
+      n: "vIqz-4-ER_vNWLON9yv8hIYV737JQ6rCl6XfzOC628seYUPf0TaGk91CFxefhzh23V9Tkq-RtwN1Vs_z57hO82kkzL-cQHZX3bMJD-GEGOKXCEXURN7VMyZWMAuzQoW9vFb1k3cR1RW_EW_P-C8bb2dCGXhBYqPfHyimvz2WarXhntPSbM5XyS5v5yCw5T_Vuwqqsio3V8wooWGMpp61y12NhN8bNVDQAkDPNu2DT9DXB1g0CeFINp_KAS_qQ2Kq6TSvRHJqxRR68RezYtje9KAqwqx4jxlmVAQy0T3-T-IAbsk1wRtWDndhO6s1Os-dck5TzyZ_dNOhfXgelixLUQ"
+    };
+    var key2 = {
+      e: "AQAB",
+      kid: "YbRAQRYcE_motWVJKHrwLBbd_9s",
+      n: "vbcFrj193Gm6zeo5e2_y54Jx49sIgScv-2JO-n6NxNqQaKVnMkHcz-S1j2FfpFngotwGMzZIKVCY1SK8SKZMFfRTU3wvToZITwf3W1Qq6n-h-abqpyJTaqIcfhA0d6kEAM5NsQAKhfvw7fre1QicmU9LWVWUYAayLmiRX6o3tktJq6H58pUzTtx_D0Dprnx6z5sW-uiMipLXbrgYmOez7htokJVgDg8w-yDFCxZNo7KVueUkLkxhNjYGkGfnt18s7ZW036WoTmdaQmW4CChf_o4TLE5VyGpYWm7I_-nV95BBvwlzokVVKzveKf3l5UU3c6PkGy-BB3E_ChqFm6sPWw"
+    };
+    var correctPemKey2 = "-----BEGIN RSA PUBLIC KEY-----\n" + 
+                     "MIIBCgKCAQEAvbcFrj193Gm6zeo5e2/y54Jx49sIgScv+2JO+n6NxNqQaKVnMkHc\n" +
+                     "z+S1j2FfpFngotwGMzZIKVCY1SK8SKZMFfRTU3wvToZITwf3W1Qq6n+h+abqpyJT\n" +
+                     "aqIcfhA0d6kEAM5NsQAKhfvw7fre1QicmU9LWVWUYAayLmiRX6o3tktJq6H58pUz\n" +
+                     "Ttx/D0Dprnx6z5sW+uiMipLXbrgYmOez7htokJVgDg8w+yDFCxZNo7KVueUkLkxh\n" +
+                     "NjYGkGfnt18s7ZW036WoTmdaQmW4CChf/o4TLE5VyGpYWm7I/+nV95BBvwlzokVV\n" +
+                     "KzveKf3l5UU3c6PkGy+BB3E/ChqFm6sPWwIDAQAB\n" + 
+                     "-----END RSA PUBLIC KEY-----\n";
+    m.oidc = {keys: [key1, key2]};
+
+    test.doesNotThrow(
+      () => {
+        var pem = m.generateOidcPEM(key2.kid);
+        test.ok(pem === correctPemKey2, 'get the correct pem');
+      },
+      Error,
+      'should not fail with the correct keys, kid and pem'
+    );
+
+    test.throws(
+      () => {
+        // wrong kid
+        var pem = m.generateOidcPEM('wrong_kid');
+      },
+      Error,
+      "Should fail with 'a key with kid my_kid cannot be found'"
+    );
+
+    test.throws(
+      () => {
+        // missing kid
+        var pem = m.generateOidcPEM(null);
+      },
+      Error,
+      "Should fail with 'keys or kid is missing'"
+    );
+
+    test.throws(
+      () => {
+        // missing keys
+        m.oidc = {};
+        var pem = m.generateOidcPEM(key2.kid);
+      },
+      Error,
+      "Should fail with 'keys or kid is missing'"
+    );
+
+    test.done();
+  }
 };


### PR DESCRIPTION
"!keys.kid===kid" is "(!keys.kid) === kid", which condition always yields false. Therefore this bug causes us to always use the first key even the kid doesn't match, and that leads to token validation error. It should be "keys.kid !== kid".

The rsaPublicKeyPem in aadutils.js of dev branch also has problem, the `encodedPubKey` has some extra '\n' inside which yield wrong pem.

Unit tests are added.