### PR TITLE
Issue #91, TypeError: this.fail is not a function

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -210,21 +210,27 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
       },
       // handle error response
       (next) => {
-        if (!(req.query && req.query.code)) {
+        var err = undefined;
+        var err_description = undefined;
+
+        if (req.query && req.query.error) {
+          err = req.query.error;
+          err_description = req.query.error_description;
+        } else if (req.body && req.body.error) {
+          err = req.body.error;
+          err_description = req.body.error_description;
+        } else {
           return next();
         }
-        // @TODO: need more specific error handling
-        //        response might include error_code, error_details and more
 
-        // Error information pertaining to OAuth 2.0 flows is encoded in the
-        // query parameters, and should be propagated to the application.
+        log.info('Error received in the response was: ', err);
+        if (err_description)
+          log.info('Error description received in the response was: ', err_description);
 
-        log.info(`OPENID CONNECT ERROR: We are in the OpenID Connect Response with error.
-          Assumed because no auth code was in the query.`);
-        log.info('Error received was: ', req.query.error);
-
-        // pass error to `next` and handle error occurance centrally in `async.waterfall`'s callback
-        return next(req.query.error);
+        // Unfortunately, we cannot return the 'error description' to the user, since 
+        // it goes to http header by default and it usually contains characters that
+        // http header doesn't like, which causes the program to crash. 
+        return self.fail(err);
       },
       // handle authorize code response (incoming redirect after user consent was given)
       (next) => {

--- a/test/Chai-passport_test/oidc_error_test.js
+++ b/test/Chai-passport_test/oidc_error_test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ 
+ /* eslint-disable no-new */
+
+ 'use restrict';
+
+var chai = require('chai');
+var url = require('url');
+var OIDCStrategy = require('../../lib/index').OIDCStrategy;
+
+chai.use(require('chai-passport-strategy'));
+
+// Mock options required to create a OIDC strategy
+var options = {
+    callbackURL: '/returnURL',
+    clientID: 'my_client_id',
+    clientSecret: 'my_client_secret',
+    identityMetadata: 'www.example.com/metadataURL',
+    skipUserProfile: true,
+    responseType: 'form_post',
+    responseMode: 'id_token',
+    validateIssuer: true,
+    passReqToCallback: false,
+    sessionKey: 'my_key'    //optional sessionKey
+};
+
+var testStrategy = new OIDCStrategy(options, function(profile, done) {});
+
+// Mock `configure`
+// `configure` is used to calculate and set the variables required by oauth2, 
+// here we just provide the variable values.
+testStrategy.configure = function(identifier, done) {
+  var opt = {           
+    clientID: options.clientID,
+    clientSecret: options.clientSecret,
+    authorizationURL: 'www.example.com/authorizationURL',
+    tokenURL: 'www.example.com/tokenURL'
+  };
+  done(null, opt);
+};
+
+// Mock `setOptions`
+// `setOptions` is used to read and save the metadata, we don't need this in test 
+testStrategy.setOptions = function(options, metadata, next) { return next();};
+
+
+describe('OIDCStrategy error handling', function() {
+  var challenge;
+  var err = {error: 'my_error', error_description: 'my_error_description'};
+
+  var put_err_in_query = function(req) { req.query = err; }
+  var put_err_in_body = function(req) { req.query = {}; req.body = err; }
+
+  var testPrepare = function(put_err_callback) {
+  	return function(done) {
+  		chai.passport
+  		  .use(testStrategy)
+  		  .fail(function(c) { challenge = c; done(); })
+  		  .req(function(req) { put_err_callback(req); })
+  		  .authenticate({});
+  	};
+  };
+
+  describe('error in query', function() {
+  	before(testPrepare(put_err_in_query));
+
+  	it('should call fail function', function() { chai.expect(challenge).to.equal('my_error'); });
+  });
+
+  describe('error in body', function() {
+    before(testPrepare(put_err_in_body));
+
+    it('should call fail function', function() { chai.expect(challenge).to.equal('my_error'); });
+  });
+});


### PR DESCRIPTION
When there is 'error' in the response, passport should call this.fail instead of this.error. The difference is:
(1) this.error is for server error
(2) this.fail is for authentication error, where the server has no problem. In this case, the server can redirect the user to login page (or whatever page the developer sets) for authentication.