### PR TITLE
work for Jenkins policheck

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -65,11 +65,11 @@ exports.originalURL = (req) => {
 /**
  * Merge object b with object a.
  *
- *     var a = { foo: 'bar' }
+ *     var a = { something: 'bar' }
  *       , b = { bar: 'baz' };
  *
  *     utils.merge(a, b);
- *     // => { foo: 'bar', bar: 'baz' }
+ *     // => { something: 'bar', bar: 'baz' }
  *
  * @param {Object} a
  * @param {Object} b

--- a/test/Nodeunit_test/metadata_test.js
+++ b/test/Nodeunit_test/metadata_test.js
@@ -60,7 +60,7 @@ exports.metadata = {
 
     test.doesNotThrow(
       () => {
-        new Metadata('http://foo.com/federationmetadata.xml', 'wsfed', options);
+        new Metadata('http://something.com/federationmetadata.xml', 'wsfed', options);
       },
       Error,
       'Should not fail with url present'
@@ -88,7 +88,7 @@ exports.metadata = {
 
     test.throws(
       () => {
-        new Metadata('http://foo.com/federationmetadata.xml', options);
+        new Metadata('http://something.com/federationmetadata.xml', options);
       },
       Error,
       'Should fail with auth type missing'
@@ -102,7 +102,7 @@ exports.metadata = {
 
     test.throws(
       () => {
-        new Metadata('http://foo.com/federationmetadata.xml', 'wsfed');
+        new Metadata('http://something.com/federationmetadata.xml', 'wsfed');
       },
       Error,
       'Should fail with options missing'

--- a/test/Nodeunit_test/validator_test.js
+++ b/test/Nodeunit_test/validator_test.js
@@ -44,7 +44,7 @@ const Validator = require('../../lib/validator').Validator;
  test.ifError(value)
  */
 
-const checker = new Validator({ foo: Validator.isNonEmpty });
+const checker = new Validator({ something: Validator.isNonEmpty });
 
 exports.validator = {
 
@@ -54,7 +54,7 @@ exports.validator = {
 
     test.doesNotThrow(
       () => {
-        checker.validate({ foo: 'test' });
+        checker.validate({ something: 'test' });
       },
       Error,
       'Should not fail with option present'

--- a/typings/browser/ambient/express-serve-static-core/index.d.ts
+++ b/typings/browser/ambient/express-serve-static-core/index.d.ts
@@ -664,7 +664,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.set('Foo', ['bar', 'baz']);
+            *    res.set('something', ['bar', 'baz']);
             *    res.set('Accept', 'application/json');
             *    res.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
             *
@@ -724,7 +724,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.location('/foo/bar').;
+            *    res.location('/something/bar').;
             *    res.location('http://example.com');
             *    res.location('../login'); // /blog/post/1 -> /blog/login
             *
@@ -755,7 +755,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.redirect('/foo/bar');
+            *    res.redirect('/something/bar');
             *    res.redirect('http://example.com');
             *    res.redirect(301, 'http://example.com');
             *    res.redirect('http://example.com', 301);
@@ -819,7 +819,7 @@ declare module "express-serve-static-core" {
             *
             * By default will `require()` the engine based on the
             * file extension. For example if you try to render
-            * a "foo.jade" file Express will invoke the following internally:
+            * a "something.jade" file Express will invoke the following internally:
             *
             *     app.engine('jade', require('jade').__express);
             *
@@ -846,11 +846,11 @@ declare module "express-serve-static-core" {
         /**
             * Assign `setting` to `val`, or return `setting`'s value.
             *
-            *    app.set('foo', 'bar');
-            *    app.get('foo');
+            *    app.set('something', 'bar');
+            *    app.get('something');
             *    // => "bar"
-            *    app.set('foo', ['bar', 'baz']);
-            *    app.get('foo');
+            *    app.set('something', ['bar', 'baz']);
+            *    app.get('something');
             *    // => ["bar", "baz"]
             *
             * Mounted servers inherit their parent server's settings.
@@ -879,11 +879,11 @@ declare module "express-serve-static-core" {
         /**
             * Check if `setting` is enabled (truthy).
             *
-            *    app.enabled('foo')
+            *    app.enabled('something')
             *    // => false
             *
-            *    app.enable('foo')
-            *    app.enabled('foo')
+            *    app.enable('something')
+            *    app.enabled('something')
             *    // => true
             */
         enabled(setting: string): boolean;
@@ -891,11 +891,11 @@ declare module "express-serve-static-core" {
         /**
             * Check if `setting` is disabled.
             *
-            *    app.disabled('foo')
+            *    app.disabled('something')
             *    // => true
             *
-            *    app.enable('foo')
-            *    app.disabled('foo')
+            *    app.enable('something')
+            *    app.disabled('something')
             *    // => false
             *
             * @param setting

--- a/typings/browser/ambient/node/index.d.ts
+++ b/typings/browser/ambient/node/index.d.ts
@@ -1046,7 +1046,7 @@ declare module "child_process" {
     export function execFile(file: string, options?: ExecFileOptions, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: ExecFileOptionsWithStringEncoding, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
-    // usage. child_process.execFile("file.sh", ["foo"], {encoding: null as string}, (err, stdout, stderr) => {});
+    // usage. child_process.execFile("file.sh", ["something"], {encoding: null as string}, (err, stdout, stderr) => {});
     export function execFile(file: string, args?: string[], options?: ExecFileOptionsWithBufferEncoding, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: ExecFileOptions, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
 

--- a/typings/main/ambient/express-serve-static-core/index.d.ts
+++ b/typings/main/ambient/express-serve-static-core/index.d.ts
@@ -664,7 +664,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.set('Foo', ['bar', 'baz']);
+            *    res.set('something', ['bar', 'baz']);
             *    res.set('Accept', 'application/json');
             *    res.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
             *
@@ -724,7 +724,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.location('/foo/bar').;
+            *    res.location('/something/bar').;
             *    res.location('http://example.com');
             *    res.location('../login'); // /blog/post/1 -> /blog/login
             *
@@ -755,7 +755,7 @@ declare module "express-serve-static-core" {
             *
             * Examples:
             *
-            *    res.redirect('/foo/bar');
+            *    res.redirect('/something/bar');
             *    res.redirect('http://example.com');
             *    res.redirect(301, 'http://example.com');
             *    res.redirect('http://example.com', 301);
@@ -819,7 +819,7 @@ declare module "express-serve-static-core" {
             *
             * By default will `require()` the engine based on the
             * file extension. For example if you try to render
-            * a "foo.jade" file Express will invoke the following internally:
+            * a "something.jade" file Express will invoke the following internally:
             *
             *     app.engine('jade', require('jade').__express);
             *
@@ -846,11 +846,11 @@ declare module "express-serve-static-core" {
         /**
             * Assign `setting` to `val`, or return `setting`'s value.
             *
-            *    app.set('foo', 'bar');
-            *    app.get('foo');
+            *    app.set('something', 'bar');
+            *    app.get('something');
             *    // => "bar"
-            *    app.set('foo', ['bar', 'baz']);
-            *    app.get('foo');
+            *    app.set('something', ['bar', 'baz']);
+            *    app.get('something');
             *    // => ["bar", "baz"]
             *
             * Mounted servers inherit their parent server's settings.
@@ -879,11 +879,11 @@ declare module "express-serve-static-core" {
         /**
             * Check if `setting` is enabled (truthy).
             *
-            *    app.enabled('foo')
+            *    app.enabled('something')
             *    // => false
             *
-            *    app.enable('foo')
-            *    app.enabled('foo')
+            *    app.enable('something')
+            *    app.enabled('something')
             *    // => true
             */
         enabled(setting: string): boolean;
@@ -891,11 +891,11 @@ declare module "express-serve-static-core" {
         /**
             * Check if `setting` is disabled.
             *
-            *    app.disabled('foo')
+            *    app.disabled('something')
             *    // => true
             *
-            *    app.enable('foo')
-            *    app.disabled('foo')
+            *    app.enable('something')
+            *    app.disabled('something')
             *    // => false
             *
             * @param setting

--- a/typings/main/ambient/node/index.d.ts
+++ b/typings/main/ambient/node/index.d.ts
@@ -1046,7 +1046,7 @@ declare module "child_process" {
     export function execFile(file: string, options?: ExecFileOptions, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: ExecFileOptionsWithStringEncoding, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
-    // usage. child_process.execFile("file.sh", ["foo"], {encoding: null as string}, (err, stdout, stderr) => {});
+    // usage. child_process.execFile("file.sh", ["something"], {encoding: null as string}, (err, stdout, stderr) => {});
     export function execFile(file: string, args?: string[], options?: ExecFileOptionsWithBufferEncoding, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: ExecFileOptions, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
 


### PR DESCRIPTION
Jenkins policheck script doesn't like the word 'foo', we are replacing 'foo' with the word 'something' so the policheck can pass.