### PR TITLE
Issue #146, duplicate use of "new Buffer"

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -205,10 +205,7 @@ Metadata.prototype.generateOidcPEM = function generateOidcPEM(kid) {
     }
 
     // generate PEM from `modulus` and `exponent`
-    const modulus = new Buffer(key.n, 'base64');
-    const exponent = new Buffer(key.e, 'base64');
-
-    pubKey = aadutils.rsaPublicKeyPem(modulus, exponent);
+    pubKey = aadutils.rsaPublicKeyPem(key.n, key.e);
     foundKey = true;
     
     return pubKey;

--- a/lib/tokenValidator.js
+++ b/lib/tokenValidator.js
@@ -60,11 +60,8 @@ TokenValidator.prototype.generateOidcPEM = function generateOidcPEM(kid) {
         log.warn('exponent was empty. Key was corrupt');
         return null;
       }
-      const modulus = new Buffer(this.metadata.oidc.keys[i].n, 'base64');
-      const exponent = new Buffer(this.metadata.oidc.keys[i].e, 'base64');
 
-      const pubKey = aadutils.rsaPublicKeyPem(modulus, exponent);
-
+      const pubKey = aadutils.rsaPublicKeyPem(this.metadata.oidc.keys[i].n, this.metadata.oidc.keys[i].e);
       log.info(`Received public key of: ${pubKey}`);
 
       return pubKey;


### PR DESCRIPTION
When we have key.n or key.e, we turn it into base64 encoded buffer
```
    var modulus64 = new Buffer(key.n, 'base64');
```
Later we feed it to rsaPublicKeyPem function, which does:
```
    var modulus =  new Buffer(modulus64, 'base64');
```

Here modulus and modulus64 are the same. Since Buffer(buffer) only takes 1 parameter, 'base64' will be ignored, and this function just makes a copy of modulus. Therefore, we just need to feed key.n or key.e to rasPublicKeyPem instead of turning it into buffer first.