### PR TITLE
Typo in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function loadGrunt(grunt) {
         options: {
           reporter: 'spec',
         },
-        src: ['test/chai-passport_test/*_test.js'],
+        src: ['test/Chai-passport_test/*_test.js'],
       },
     },
     eslint: {


### PR DESCRIPTION
Folder name should be `Chai-passport_test` instead of `chai-passport_test`. Tests in this folder run locally, but not on travis, seems my version of npm doesn't distinguish the lower/upper case.