### PR TITLE
package json mistake

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "test": "grunt run_all_tests"
   },
   "engines": {
-    "node": ">= ~4.0.1"
+    "node": ">= 4.0.1"
   }
 }


### PR DESCRIPTION
">= ~4.0.1" is illegal use, a comparator is composed of an operator and a version (see https://github.com/npm/node-semver and the range grammar). My testing shows ">= ~4.0.1" has the same effect as "~4.0.1", which means only v4.0.x is wanted. This is in fact the issue Jeff Wilconx mentioned in his email, where he was using v4.4.7 and got a warning. The correct one should be ">= 4.0.1".