### PR TITLE
Issue #71

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -143,6 +143,22 @@ function Strategy(options, verify) {
       This is fine if you are expecting multiple organizations to connect to your app.
       Otherwise you should validate the issuer.`);
   }
+
+  // validate other necessary option items provided, we validate them here and only once
+  var itemsToValidate = objectTransform({
+    source: options,
+    pick: ['clientID', 'callbackURL', 'responseType', 'responseMode']
+  });
+  var validatorConfiguration = {
+    clientID: Validator.isNonEmpty,
+    callbackURL: Validator.isNonEmpty,
+    // callbackURL: Validator.isURL  // We allow http for now
+    responseType: Validator.isTypeLegal,
+    responseMode: Validator.isModeLegal
+  };
+  // validator will throw exception if a required option is missing
+  var validator = new Validator(validatorConfiguration);
+  validator.validate(itemsToValidate);
 }
 
 // Inherit from `passport.Strategy`.
@@ -619,13 +635,8 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) 
 
       // Now that we have our options for configuration, let's check them for issues.
       const validatorConfig = {
-        clientID: Validator.isNonEmpty,
-        callbackURL: Validator.isNonEmpty,
-        responseType: Validator.isTypeLegal,
-        responseMode: Validator.isModeLegal,
         authorizationURL: Validator.isURL,
         tokenURL: Validator.isURL,
-        // callbackURL: Validator.isURL  // We allow http for now :-/
       };
 
       // validator will throw exception if a required option is missing

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -147,14 +147,14 @@ function Strategy(options, verify) {
   // validate other necessary option items provided, we validate them here and only once
   var itemsToValidate = objectTransform({
     source: options,
-    pick: ['clientID', 'callbackURL', 'responseType', 'responseMode']
+    pick: ['clientID', 'callbackURL', 'responseType', 'responseMode', 'identityMetadata']
   });
   var validatorConfiguration = {
     clientID: Validator.isNonEmpty,
-    callbackURL: Validator.isNonEmpty,
-    // callbackURL: Validator.isURL  // We allow http for now
+    callbackURL: Validator.isURL,   // allow http so developer can use http://localhost:3000
     responseType: Validator.isTypeLegal,
-    responseMode: Validator.isModeLegal
+    responseMode: Validator.isModeLegal,
+    identityMetadata: Validator.isHttpsURL
   };
   // validator will throw exception if a required option is missing
   var validator = new Validator(validatorConfiguration);
@@ -635,8 +635,8 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) 
 
       // Now that we have our options for configuration, let's check them for issues.
       const validatorConfig = {
-        authorizationURL: Validator.isURL,
-        tokenURL: Validator.isURL,
+        authorizationURL: Validator.isHttpsURL,
+        tokenURL: Validator.isHttpsURL,
       };
 
       // validator will throw exception if a required option is missing

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -23,6 +23,8 @@
 
 'use strict';
 
+const UrlValidator = require('valid-url');
+
 const types = {};
 
 function Validator(config) {
@@ -77,16 +79,24 @@ types.isModeLegal = {
 
 Validator.isURL = 'isURL';
 types.isURL = {
-
   validate: (value) => {
-    const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locator
+    return UrlValidator.isHttpUri(value) || UrlValidator.isHttpsUri(value);
+  },
+  error: 'The URL must be valid and be https:// or http://',
+};
 
-    return !!pattern.test(value);
+Validator.isHttpURL = 'isHttpURL';
+types.isHttpURL = {
+  validate: (value) => {
+    return UrlValidator.isHttpUri(value);
+  },
+  error: 'The URL must be valid and be http://',
+};
+
+Validator.isHttpsURL = 'isHttpsURL';
+types.isHttpsURL = {
+  validate: (value) => {
+    return UrlValidator.isHttpsUri(value);
   },
   error: 'The URL must be valid and be https://',
 };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "request": "^2.72.0",
     "underscore": "^1.8.3",
     "webfinger": "^0.4.2",
+    "valid-url": "^1.0.6",
     "xml-crypto": "^0.8.4",
     "xml2js": "^0.4.16",
     "xmldom": "^0.1.22",

--- a/test/Chai-passport_test/oidc_error_test.js
+++ b/test/Chai-passport_test/oidc_error_test.js
@@ -33,10 +33,10 @@ chai.use(require('chai-passport-strategy'));
 
 // Mock options required to create a OIDC strategy
 var options = {
-    callbackURL: '/returnURL',
+    callbackURL: 'http://returnURL',
     clientID: 'my_client_id',
     clientSecret: 'my_client_secret',
-    identityMetadata: 'www.example.com/metadataURL',
+    identityMetadata: 'https://www.example.com/metadataURL',
     skipUserProfile: true,
     responseType: 'id_token',
     responseMode: 'form_post',
@@ -54,8 +54,8 @@ testStrategy.configure = function(identifier, done) {
   var opt = {           
     clientID: options.clientID,
     clientSecret: options.clientSecret,
-    authorizationURL: 'www.example.com/authorizationURL',
-    tokenURL: 'www.example.com/tokenURL'
+    authorizationURL: 'https://www.example.com/authorizationURL',
+    tokenURL: 'https://www.example.com/tokenURL'
   };
   done(null, opt);
 };

--- a/test/Chai-passport_test/oidc_error_test.js
+++ b/test/Chai-passport_test/oidc_error_test.js
@@ -38,8 +38,8 @@ var options = {
     clientSecret: 'my_client_secret',
     identityMetadata: 'www.example.com/metadataURL',
     skipUserProfile: true,
-    responseType: 'form_post',
-    responseMode: 'id_token',
+    responseType: 'id_token',
+    responseMode: 'form_post',
     validateIssuer: true,
     passReqToCallback: false,
     sessionKey: 'my_key'    //optional sessionKey

--- a/test/Nodeunit_test/oidc_b2c_test.js
+++ b/test/Nodeunit_test/oidc_b2c_test.js
@@ -60,6 +60,10 @@ exports.oidc = {
       identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
       tenantName: 'hypercubeb2c.onmicrosoft.com',
       forceB2C: true,
+      clientID: '123',
+      callbackURL: 'www.example.com',
+      responseType: 'id_token',
+      responseMode: 'form_post'
     };
 
     test.doesNotThrow(

--- a/test/Nodeunit_test/oidc_b2c_test.js
+++ b/test/Nodeunit_test/oidc_b2c_test.js
@@ -61,7 +61,7 @@ exports.oidc = {
       tenantName: 'hypercubeb2c.onmicrosoft.com',
       forceB2C: true,
       clientID: '123',
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_token',
       responseMode: 'form_post'
     };

--- a/test/Nodeunit_test/oidc_test.js
+++ b/test/Nodeunit_test/oidc_test.js
@@ -93,7 +93,7 @@ exports.oidc = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
       clientID: '',  // invalid
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_token',
       responseMode: 'form_post'
     };
@@ -137,7 +137,7 @@ exports.oidc = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
       clientID: '123',
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_tokennn', // invalid
       responseMode: 'form_post'
     };
@@ -159,7 +159,7 @@ exports.oidc = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
       clientID: '123',
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_token',
       responseMode: 'fragment' // invalid
     };
@@ -181,7 +181,7 @@ exports.oidc = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
       clientID: '123',
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_token',
       responseMode: 'form_post'
     };

--- a/test/Nodeunit_test/oidc_test.js
+++ b/test/Nodeunit_test/oidc_test.js
@@ -85,54 +85,105 @@ exports.oidc = {
 
     test.done();
   },
-  'with missing option resposneType': (test) => {
+  'with invalid option clientID': (test) => {
     test.expect(1);
     // tests here
 
     const oidcConfig = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-      responseType: 'id_tokennn', // for login only flows use id_token. For accessing resources use `id_token code`
+      clientID: '',  // invalid
+      callbackURL: 'www.example.com',
+      responseType: 'id_token',
+      responseMode: 'form_post'
     };
     test.throws(
       () => {
         const s = new OidcStrategy(oidcConfig, noop);
-        s.loadOptions(oidcConfig, noop);
       },
       TypeError,
-      'Should fail with wrong reponses config options'
+      'Should fail with wrong response config options'
     );
 
     test.done();
   },
-  'with missing option resposneMode': (test) => {
+  'with invalid option callbackURL': (test) => {
     test.expect(1);
     // tests here
 
     const oidcConfig = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-      responseMode: 'fragment', // For login only flows we should have token passed back to us in a POST
+      clientID: '123',
+      callbackURL: '',  // invalid
+      responseType: 'id_tokennn',
+      responseMode: 'form_post'
     };
     test.throws(
       () => {
         const s = new OidcStrategy(oidcConfig, noop);
-        s.loadOptions(oidcConfig, noop);
       },
-      Error,
-      'Should fail with wrong reponses config options'
+      TypeError,
+      'Should fail with wrong response config options'
     );
 
     test.done();
   },
-  'with options': (test) => {
+  'with invalid option responseType': (test) => {
     test.expect(1);
     // tests here
 
     const oidcConfig = {
       // required options
-      identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
-      issuer: 'http://localhost:3000', // this is the URI you entered for APP ID URI when configuring SSO for you app on Azure AAD
+      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      clientID: '123',
+      callbackURL: 'www.example.com',
+      responseType: 'id_tokennn', // invalid
+      responseMode: 'form_post'
+    };
+    test.throws(
+      () => {
+        const s = new OidcStrategy(oidcConfig, noop);
+      },
+      TypeError,
+      'Should fail with wrong response config options'
+    );
+
+    test.done();
+  },
+  'with invalid option responseMode': (test) => {
+    test.expect(1);
+    // tests here
+
+    const oidcConfig = {
+      // required options
+      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      clientID: '123',
+      callbackURL: 'www.example.com',
+      responseType: 'id_token',
+      responseMode: 'fragment' // invalid
+    };
+    test.throws(
+      () => {
+        const s = new OidcStrategy(oidcConfig, noop);
+      },
+      Error,
+      'Should fail with wrong response config options'
+    );
+
+    test.done();
+  },
+  'with valid options': (test) => {
+    test.expect(1);
+    // tests here
+
+    const oidcConfig = {
+      // required options
+      identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      clientID: '123',
+      callbackURL: 'www.example.com',
+      responseType: 'id_token',
+      responseMode: 'form_post'
     };
 
     test.doesNotThrow(

--- a/test/Nodeunit_test/oidc_v2_test.js
+++ b/test/Nodeunit_test/oidc_v2_test.js
@@ -74,7 +74,7 @@ exports.oidc = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
       clientID: '123',
-      callbackURL: 'www.example.com',
+      callbackURL: 'http://www.example.com',
       responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
       responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
     };

--- a/test/Nodeunit_test/oidc_v2_test.js
+++ b/test/Nodeunit_test/oidc_v2_test.js
@@ -73,6 +73,8 @@ exports.oidc = {
     const oidcConfig = {
       // required options
       identityMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+      clientID: '123',
+      callbackURL: 'www.example.com',
       responseType: 'id_token', // for login only flows use id_token. For accessing resources use `id_token code`
       responseMode: 'form_post', // For login only flows we should have token passed back to us in a POST
     };


### PR DESCRIPTION
Some properties (clientID, callbackURL, responseType, responseMode) from the provided options are checked in the `authenticate` time, this is not good because:
(1) code should crash immediately instead of the time when `authenticate` is called, immediate crash gives the user immediate feedback of their configuration error
(2) these properties are checked for every request that needs `authenticate`. This is not necessary since the value of these properties would be changed.
Considering all these, we now check them at the creation time of strategy.