### PR TITLE
Issue #111 and #157  Add security checks for oidcstrategy

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -22,6 +22,7 @@
  */
 'use strict';
 
+const base64url = require('base64url');
 const crypto = require('crypto');
 const util = require('util');
 
@@ -154,4 +155,22 @@ exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
   const pem = `-----BEGIN RSA PUBLIC KEY-----\n${derB64.match(/.{1,64}/g).join('\n')}\n-----END RSA PUBLIC KEY-----\n`;
 
   return pem;
+};
+
+// used for c_hash and at_hash validation
+// case (1): content = access_token, hashProvided = at_hash
+// case (2): content = code, hashProvided = c_hash
+exports.checkHashValueRS256 = (content, hashProvided) => {
+  // step 1. hash the content
+  var digest = crypto.createHash('sha256').update(content).digest();
+
+  // step2. take the first half of the digest, and save it in a buffer
+  var buffer = new Buffer(digest.length/2);
+  for (var i = 0; i < buffer.length; i++)
+    buffer[i] = digest[i];
+
+  // step 3. base64url encode the buffer to get the hash
+  var hashComputed = base64url(buffer);
+
+  return (hashProvided === hashComputed);
 };

--- a/lib/nonceHandler.js
+++ b/lib/nonceHandler.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+ 'use restrict';
+
+ exports.verifyNonce = function(req, sessionKey, nonce_in_idtoken) {
+	if (!req.session) {
+		return {valid: false, errorMessage: 'OIDC strategy requires session support. Did you forget to use express-session middleware?'};
+	}
+
+	// the nonce we provided before should be in req.session[sessionKey]
+	var nonce_provided = req.session[sessionKey] && req.session[sessionKey].nonce;
+	if (!nonce_provided)
+		return {valid: false, errorMessage: 'nonce was not provided'};
+
+	// clear the nonce saved in session, and clear the session if there is nothing inside
+	delete req.session[sessionKey].nonce;
+	if (Object.keys(req.session[sessionKey]).length ===0)
+		delete req.session[sessionKey];
+
+	// compare the two states
+	if (nonce_in_idtoken !== nonce_provided)
+		return {valid:false, errorMessage: 'invalid nonce in id_token'};
+
+	return {valid: true, errorMessage: ''};
+};
+
+ exports.addNonceToSession = function(req, sessionKey, nonce) {
+	if (!req.session) {
+		return {valid: false, errorMessage: 'OIDC strategy requires session support. Did you forget to use express-session middleware?'};
+	}
+	if (!req.session[sessionKey])
+		req.session[sessionKey] = {};
+	req.session[sessionKey].nonce = nonce;
+}

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -25,24 +25,27 @@
 
 /* eslint no-underscore-dangle: 0 */
 
-const url = require('url');
+const async = require('async');
+const cacheManager = require('cache-manager');
+const _ = require('lodash');
+const jws = require('jws');
+const jwt = require('jsonwebtoken');
+const OAuth2 = require('oauth').OAuth2;
+const objectTransform = require('oniyi-object-transform');
+const passport = require('passport');
 const querystring = require('querystring');
+const url = require('url');
 const util = require('util');
 
-const async = require('async');
-const _ = require('lodash');
-const passport = require('passport');
-const OAuth2 = require('oauth').OAuth2;
-const cacheManager = require('cache-manager');
-const objectTransform = require('oniyi-object-transform');
-
-const utils = require('./aadutils');
-const setup = require('./oidcsetup');
-const Validator = require('./validator').Validator;
-const Log = require('./logging').getLogger;
 const InternalOAuthError = require('./errors/internaloautherror');
 const InternalOpenIDError = require('./errors/internalopeniderror');
+const Log = require('./logging').getLogger;
 const Metadata = require('./metadata').Metadata;
+const nonceHandler = require('./nonceHandler');
+const setup = require('./oidcsetup');
+const stateHandler = require('./stateHandler');
+const utils = require('./aadutils');
+const Validator = require('./validator').Validator;
 
 // global variable definitions
 const log = new Log('AzureAD: OIDC Passport Strategy');
@@ -119,19 +122,59 @@ function onProfileLoaded(strategy, args) {
  */
 function Strategy(options, verify) {
   passport.Strategy.call(this);
+
+  /*
+   *  Caution when you want to change these values in the member functions of
+   *  Strategy, don't use `this`, since `this` points to a subclass of `Strategy`.
+   *  To get `Strategy`, use Object.getPrototypeOf(this).
+   *  
+   *  More comments at the beginning of `Strategy.prototype.authenticate`. 
+   */
   this._options = options;
   this.name = 'azuread-openidconnect';
   this._verify = verify;
   this._configurers = [];
-  this._cacheKey = 'ordinary';
   this._skipUserProfile = !!options.skipUserProfile;
   this._passReqToCallback = !!options.passReqToCallback;
 
+  /* When a user is authenticated for the first time, passport adds a new field
+   * to req.session called 'passport', and puts a 'user' property inside (or your
+   * choice of field name and property name if you change passport._key and 
+   * passport._userProperty values). req.session['passport']['user'] is usually 
+   * user_id (or something similar) of the authenticated user to reduce the size
+   * of session. When the user logs out, req.session['passport']['user'] will be
+   * destroyed. Any request between login (when authenticated for the first time)
+   * and logout will have the 'user_id' in req.session['passport']['user'], so
+   * passport can fetch it, find the user object in database and put the user
+   * object into a new field: req.user. Then the subsequent middlewares and the 
+   * app can use the user object. This is how passport keeps user authenticated. 
+   *
+   * For state validation, we also take advantage of req.session. we create a new
+   * field: req.session[sessionKey], where the sessionKey is our choice (in fact, 
+   * this._key, see below). When we send a request with state, we put state into
+   * req.session[sessionKey].state; when we expect a request with state in query
+   * or body, we compare the state in query/body with the one stored in 
+   * req.session[sessionKey].state, and then destroy req.session[sessionKey].state.
+   * User can provide a state by using `authenticate(Strategy, {state: 'xxx'})`, or
+   * one will be generated automatically. This is essentially how passport-oauth2
+   * library does the state validation, and we use the same way in our library. 
+   *
+   * request structure will look like the following. In real request some fields
+   * might not be there depending on the purpose of the request.
+   *
+   *    request ---|--- sessionID
+   *               |--- session --- |--- ...
+   *               |                |--- 'passport' ---| --- 'user': 'user_id etc'
+   *               |                |---  sessionKey---| --- state: 'xxx'            
+   *               |--- ...
+   *               |--- 'user':  full user info
+   */
+  this._key = options.sessionKey || ('OIDC: ' + options.callbackURL);
+
   if (!options.identityMetadata) {
     // default value should be https://login.microsoftonline.com/common/.well-known/openid-configuration
-    log.error('No options was presented to Strategy as required.');
-    throw new TypeError(`OIDCStrategy requires either a PEM encoded public key
-      or a metadata location that contains cert data for RSA and ECDSA callback.`);
+    log.error('OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.');
+    throw new TypeError(`OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.`);
   }
 
   // if logging level specified, switch to it.
@@ -159,6 +202,10 @@ function Strategy(options, verify) {
   // validator will throw exception if a required option is missing
   var validator = new Validator(validatorConfiguration);
   validator.validate(itemsToValidate);
+
+  // check if Azure v2.0 is being used, v2.0 doesn't have a userinfo endpoint
+  if (options.identityMetadata.indexOf('/v2.0/') != -1)
+    this._options._isV2 = true;
 }
 
 // Inherit from `passport.Strategy`.
@@ -172,6 +219,44 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
+  /* 
+   * We should be careful using 'this'. Avoid the usage like `this.xxx = ...`
+   * unless you know what you are doing.
+   *
+   * In the passport source code 
+   * (https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js)
+   * when it attempts to call the `oidcstrategy.authenticate` function, passport
+   * creates an instance inherting oidcstrategy and then calls `instance.authenticate`.  
+   * Therefore, when we come here, `this` is the instance, its prototype is the
+   * actual oidcstrategy, i.e. the `Strategy`. This means:
+   * (1) `this._options = `, `this._verify = `, etc only adds new fields to the
+   *      instance, it doesn't change the values in oidcstrategy, i.e. `Strategy`. 
+   * (2) `this._options`, `this._verify`, etc returns the field in the instance,
+   *     and if there is none, returns the field in oidcstrategy, i.e. `strategy`.
+   * (3) each time we call `authenticate`, we will get a brand new instance
+   * 
+   * If you want to change the values in `Strategy`, use 
+   *      const oidcstrategy = Object.getPrototypeOf(self);
+   * to get the strategy first.
+   *
+   * Note: Simply do `const self = Object.getPrototypeOf(this)` and use `self`
+   * won't work, since the `this` instance has a couple of functions like
+   * success/fail/error... which `authenticate` will call. The following is the
+   * structure of `this`:
+   *
+   *   this
+   *   | --  success:  function(user, info)
+   *   | --  fail:     function(challenge, status)
+   *   | --  redirect: function(url, status)
+   *   | --  pass:     function()
+   *   | --  __proto__:  Strategy
+   *                 | --  _verify
+   *                 | --  _options
+   *                 | --  ...
+   *                 | --  __proto__:
+   *                              | --  authenticate:  function(req, options)
+   *                              | --  ...
+   */ 
   const self = this;
 
   // Allow for some overrides that may come in to the authenticate strategy.
@@ -187,10 +272,16 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 
   async.waterfall(
     [
-      // compute metadata url
+      /* 
+       * Step 1. compute metadata url 
+       */
       (next) => {
         // B2C interception
-        let metadata = self._options.identityMetadata;
+        let metadataUrl = self._options.identityMetadata;
+
+        // use 'ordinary' as the default cachekey, in the case of B2C, we will
+        // change the value to policy later
+        let cachekey = 'ordinary';
 
         // We listen for the p paramter in any response and set it. If it has been set already and in memory (profile) we skip this as it's not necessary to set again.
         // @TODO when forceB2C is set but no req.query.p is present, the policy variable would be 'undefined'
@@ -207,350 +298,76 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
           // @TODO: could be undefined
           const policy = req.query.p;
 
-          // @TODO: assumes that self._options.identityMetadata is of type string.
-          //        according to Strategy constructor, it could also be a PEM encodede public key
-          metadata = self._options.identityMetadata
+          metadataUrl = self._options.identityMetadata
             .replace('common', self._options.tenantName)
             .concat(`?p=${policy}`);
 
-          self._cacheKey = policy; // this policy will become cache key.
+          cachekey = 'policy: ' + policy; // this policy will become cache key.
 
-          log.info('B2C: New Metadata url provided to Strategy was: ', metadata);
+          log.info('B2C: New Metadata url provided to Strategy was: ', metadataUrl);
         }
 
-        return next(null, metadata);
-      },
-      // load options from metadata url
-      (metadata, next) => {
-        self.setOptions(self._options, metadata, next);
-      },
-      // handle error response
-      (next) => {
-        var err = undefined;
-        var err_description = undefined;
+        self.metadata = new Metadata(metadataUrl, 'oidc', self._options);
 
-        if (req.query && req.query.error) {
-          err = req.query.error;
-          err_description = req.query.error_description;
-        } else if (req.body && req.body.error) {
-          err = req.body.error;
-          err_description = req.body.error_description;
+        return next(null, metadataUrl, cachekey);
+      },
+
+      /* 
+       * Step 2. load options from metadata url
+       */
+      (metadataUrl, cachekey, next) => {
+        return self.setOptions(self._options, metadataUrl, cachekey, next);
+      },
+
+      /* 
+       * Step 3. the following are the scenarios for the coming request
+       * (1) error response
+       * (1) implicit flow (response_type = 'id_token')
+       *     This case we get a 'id_token'
+       * (2) hybrid flow (response_type = 'id_token code')
+       *     This case we get both 'id_token' and 'code'
+       * (3) authorization code flow (response_type = 'code')
+       *     This case we get a 'code', we will use it to get 'access_token' and 'id_token'
+       * (5) for any other request, we will ask for authorization and initialize the authorization process 
+       */
+      (next) => {
+        var err, err_description, id_token, code;
+        err = err_description = id_token = code = undefined;
+
+        if (req.body && req.body.error) err = req.body.error;
+        if (req.body && req.body.error_description) err_description = req.body.error_description;
+        if (req.body && req.body.id_token) id_token = req.body.id_token;
+        if (req.body && req.body.code) code = req.body.code;
+
+        if (!err && !id_token && !code) {
+          // ask for authorization, initialize the authorization process
+          return self._flowInitializationHandler(req, next);
+        }
+
+        // check state
+        var stateCheckResult = stateHandler.verifyState(req, self._key);
+        if (!stateCheckResult.valid) {
+          return self.fail(stateCheckResult.errorMessage);
+        }
+
+        if (err) {
+          // handle error response
+          return self._errorResponseHandler(err, err_description);
+        } else if (id_token && code) {
+          // handle hybrid flow
+          return self._hybridFlowHandler(id_token, code, req, next);
+        } else if (id_token) {
+          // handle implicit flow
+          return self._implicitFlowHandler(id_token, req, next);
         } else {
-          return next();
+          // handle authorization code flow
+          return self._authCodeFlowHandler(code, req, next);
         }
-
-        log.info('Error received in the response was: ', err);
-        if (err_description)
-          log.info('Error description received in the response was: ', err_description);
-
-        // Unfortunately, we cannot return the 'error description' to the user, since 
-        // it goes to http header by default and it usually contains characters that
-        // http header doesn't like, which causes the program to crash. 
-        return self.fail(err);
-      },
-      // handle authorize code response (incoming redirect after user consent was given)
-      (next) => {
-        if (!(
-            (req.method === 'GET' && req.query && req.query.code) ||
-            (req.method === 'POST' && req.body && req.body.code))) {
-          return next();
-        }
-        const code = (req.query && req.query.code) ? req.query.code : req.body.code;
-
-        if (!code) {
-          return next(new Error('Failed to extract `code` from request object'));
-        }
-
-        log.info('OAUTH2: Got access code: ', code);
-
-        // use `null` as identifier since we are in the callback phase of OAuth 2.0 Dance already
-        // identifier only has impact on the `authorize` endpoint
-        return self.configure(null, (err, config) => {
-          if (err) {
-            return next(err);
-          }
-
-          const oauth2 = new OAuth2(
-            config.clientID, // consumerKey
-            config.clientSecret, // consumer secret
-            '', // baseURL (empty string because we use absolute urls for authorize and token paths)
-            config.authorizationURL, // authorizePath
-            config.tokenURL, // accessTokenPath
-            {} // customHeaders
-          );
-
-          let callbackURL = config.callbackURL;
-          // options.callbackURL is merged into config object while `setOptions` call
-          if (!callbackURL) {
-            return next(new Error('no callbackURL found'));
-          }
-
-          const parsedCallbackURL = url.parse(callbackURL);
-          if (!parsedCallbackURL.protocol) {
-            // The callback URL is relative, resolve a fully qualified URL from the
-            // URL of the originating request.
-            callbackURL = url.resolve(utils.originalURL(req), callbackURL);
-          }
-
-          return oauth2.getOAuthAccessToken(code, {
-            grant_type: 'authorization_code',
-            redirect_uri: callbackURL,
-          }, (getOAuthAccessTokenError, accessToken, refreshToken, params) => {
-            if (getOAuthAccessTokenError) {
-              return next(new InternalOAuthError('failed to obtain access token', getOAuthAccessTokenError));
-            }
-
-            log.info('TOKENS RECEIVED: %j', {
-              accessToken,
-              refreshToken,
-              params,
-            });
-
-            const idToken = params.id_token;
-            if (!idToken) {
-              return next(new Error('ID Token not present in token response'));
-            }
-
-            const idTokenSegments = idToken.split('.');
-            let jwtClaimsStr;
-            let jwtClaims;
-
-            try {
-              jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
-              jwtClaims = JSON.parse(jwtClaimsStr);
-            } catch (ex) {
-              return next(ex);
-            }
-
-            log.info('Claims received: ', jwtClaims);
-
-            // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
-            // 'sub' claim was named 'user_id'.  Many providers still issue the
-            // claim under the old field, so fallback to that.
-            const sub = jwtClaims.sub || jwtClaims.user_id;
-            const iss = jwtClaims.iss;
-
-            // Ensure claims are validated per:
-            // http://openid.net/specs/openid-connect-basic-1_0.html#id_token
-
-            return self._shouldLoadUserProfile(iss, sub, (shouldLoadUserProfileError, load) => {
-              if (shouldLoadUserProfileError) {
-                return next(shouldLoadUserProfileError);
-              }
-
-              if (load) {
-                // version 2.0 of Azure AD endpoints does not provide a userinfo_endpoint information
-                let parsedUrl;
-                try {
-                  parsedUrl = url.parse(config.userInfoURL, true);
-                } catch (urlParseException) {
-                  return next(
-                    new InternalOpenIDError(
-                      `Failed to parse config property 'userInfoURL' with value ${config.userInfoURL}`,
-                      urlParseException
-                    )
-                  );
-                }
-                parsedUrl.query.schema = 'openid';
-                delete parsedUrl.search; // delete operations are slow; should we rather just overwrite it with {}
-                const userInfoURL = url.format(parsedUrl);
-
-                return oauth2.get(userInfoURL, refreshToken, (getUserInfoError, body) => {
-                  if (getUserInfoError) {
-                    return next(new InternalOAuthError('failed to fetch user profile', getUserInfoError));
-                  }
-
-                  log.info('PROFILE LOADED FROM MS IDENTITY', body);
-
-                  // use try / catch around JSON.parse --> could fail unexpectedly
-                  try {
-                    return onProfileLoaded(self, {
-                      req,
-                      sub,
-                      iss,
-                      profile: makeProfileObject(JSON.parse(body), body),
-                      jwtClaims,
-                      accessToken,
-                      refreshToken,
-                      params,
-                    });
-                  } catch (ex) {
-                    return next(ex);
-                  }
-                });
-              }
-
-              // lets do an id_token fallback. We use id_token over userInfo endpoint for now
-              return onProfileLoaded(self, {
-                req,
-                sub,
-                iss,
-                profile: (idToken) ? makeProfileObject(jwtClaims, jwtClaimsStr) : undefined,
-                jwtClaims,
-                accessToken,
-                refreshToken,
-                params,
-              });
-            });
-          });
-        });
-      },
-      //
-      (next) => {
-        if (!(req.body && req.method === 'POST')) {
-          return next();
-        }
-
-        log.info(`OPENID CONNECT: We are in the OpenID Connect Only Response.
-          Assumed because no auth code was in the query and we are POST.`);
-        log.info('Body received was: ', req.body);
-
-        // We are not doing auth code so we set the tokens to null
-        const accessToken = null;
-        const refreshToken = null;
-        const params = null;
-
-        // We have a response, get the user identity out of it
-        const idToken = req.body.id_token;
-        if (!idToken) {
-          return next(new Error('ID Token not present in response'));
-        }
-
-        const idTokenSegments = idToken.split('.');
-        let jwtClaimsStr;
-        let jwtClaims;
-
-        try {
-          jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
-          jwtClaims = JSON.parse(jwtClaimsStr);
-        } catch (ex) {
-          return next(ex);
-        }
-
-        log.info('Claimes received: ', jwtClaims);
-
-        // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
-        // 'sub' claim was named 'user_id'.  Many providers still issue the
-        // claim under the old field, so fallback to that.
-        const sub = jwtClaims.sub || jwtClaims.user_id;
-        const iss = jwtClaims.iss;
-
-        return self._shouldLoadUserProfile(iss, sub, (err, load) => {
-          if (err) {
-            return next(err);
-          }
-
-          if (load) {
-            // we do not have a userinfo endpoint for id token at the moment
-            // @TODO: need error handling accordingly
-          }
-
-          // lets do an id_token fallback. We use id_token over userInfo endpoint for now
-          // log.info('PROFILE FALLBACK: Since we did not use the UserInfo endpoint, falling back to id_token for profile.');
-
-          return onProfileLoaded(self, {
-            req,
-            sub,
-            iss,
-            profile: (idToken) ? makeProfileObject(jwtClaims, jwtClaimsStr) : undefined,
-            jwtClaims,
-            accessToken,
-            refreshToken,
-            params,
-          });
-        });
-      },
-      // initialize OAuth 2.0 Authorize Flow
-      (next) => {
-        // The request being authenticated is initiating OpenID Connect
-        // authentication. Prior to redirecting to the provider, configuration will
-        // be loaded. The configuration is typically either pre-configured or
-        // discovered dynamically. When using dynamic discovery, a user supplies
-        // their identifer as input.
-
-        log.info(`OPENID CONNECT: We are in the OpenID Connect Inital Flow.
-          Assumed because no auth code was in the query and we are not POST.`);
-        log.info('Body received was: ', req.body);
-
-        let identifier;
-        if (req.body && req.body[this._identifierField]) {
-          identifier = req.body[this._identifierField];
-        } else if (req.query && req.query[this._identifierField]) {
-          identifier = req.query[this._identifierField];
-        }
-
-        return self.configure(identifier, (configureError, config) => {
-          if (configureError) {
-            return next(configureError);
-          }
-
-          let callbackURL = options.callbackURL || config.callbackURL;
-          if (callbackURL) {
-            const parsed = url.parse(callbackURL);
-            if (!parsed.protocol) {
-              // The callback URL is relative, resolve a fully qualified URL from the
-              // URL of the originating request.
-              callbackURL = url.resolve(utils.originalURL(req), callbackURL);
-            }
-          }
-
-          log.info('Going in with our config loaded as: ', config);
-
-          const params = {};
-          if (self.authorizationParams) {
-            _.assign(params, self.authorizationParams(options));
-          }
-          _.assign(params, {
-            redirect_uri: callbackURL,
-            nonce: utils.uid(16),
-          }, objectTransform({
-            source: config,
-            map: {
-              responseMode: 'response_mode',
-              responseType: 'response_type',
-              clientID: 'client_id',
-              resourceURL: 'resource',
-            },
-          }));
-
-          log.info('We are sending the response_type: ', params.response_type);
-          log.info('We are sending the response_mode: ', params.response_mode);
-
-          let scope = config.scope;
-          if (Array.isArray(scope)) {
-            scope = scope.join(config.scopeSeparator);
-          }
-          if (scope) {
-            params.scope = ['openid', scope].join(config.scopeSeparator);
-          } else {
-            params.scope = 'openid';
-          }
-
-          // if (policy) { params['p'] = policy; }; // Policy parameter should be included.
-
-          // Add support for automatically generating a random state for verification.
-
-          let state;
-
-          if (!options.state) { state = utils.uid(16); } else { state = options.state; }
-
-          params.state = state;
-
-          let location;
-
-          // Implement support for standard OpenID Connect params (display, prompt, etc.)
-
-          if (req.query.p) {
-            location = `${config.authorizationURL}&${querystring.stringify(params)}`;
-          } else {
-            location = `${config.authorizationURL}?${querystring.stringify(params)}`;
-          }
-
-          return self.redirect(location);
-        });
-      },
+      }
     ],
-    (waterfallError) => { // This function gets called after the three tasks have called their 'task callbacks'
+
+    (waterfallError) => {
+      // this code gets called after the three steps above are done
       if (waterfallError) {
         return self.error(waterfallError);
       }
@@ -570,7 +387,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
  * @param {Object} options
  * @return {Object} options
  */
-Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) {
+Strategy.prototype.setOptions = function setOptions(options, metadataUrl, cachekey, done) {
   const self = this;
 
   // Loading metadata from endpoint.
@@ -579,21 +396,21 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, done) 
     function loadMetadata(next) {
       log.info('Parsing Metadata: ', metadataUrl);
 
-      memoryCache.wrap(self._cacheKey, (cacheCallback) => {
-        const metadata = new Metadata(metadataUrl, 'oidc', options);
-        metadata.fetch((fetchMetadataError) => {
+      memoryCache.wrap(cachekey, (cacheCallback) => {
+        //self.metadata = new Metadata(metadataUrl, 'oidc', options);
+        self.metadata.fetch((fetchMetadataError) => {
           if (fetchMetadataError) {
             return cacheCallback(new Error(`Unable to fetch metadata: ${fetchMetadataError}`));
           }
-          return cacheCallback(null, metadata);
+          return cacheCallback(null, self.metadata);
         });
       }, { ttl }, next);
     },
     // merge fetched metadata with options
     function loadOptions(metadata, next) {
-      // fetched metadata always takes precendence over configured options
+      self.metadata = metadata;
 
-      self._skipUserProfile = !!options.skipUserProfile;
+      // fetched metadata always takes precendence over configured options
 
       // use default values where no option is present
       const opts = {
@@ -751,5 +568,469 @@ Strategy.prototype._shouldLoadUserProfile = function shouldLoadUserProfile(issue
     this._skipUserProfile;
   return done(null, !skip);
 };
+
+/**
+ * validate id_token, and pass the validated claims and the payload to callback
+ * if code (resp. access_token) is provided, we will validate the c_hash (resp at_hash) as well
+ *
+ * @param {String} id_token
+ * @param {Object} req
+ * @param {Function} callback
+ * @param {String} code (if you want to validate c_hash)
+ * @param {String} access_token (if you want o validate at_hash)
+ */
+Strategy.prototype._validateIdToken = function validateIdToken(id_token, code, access_token, req, callback) {
+  const self = this;
+
+  // decode id_token
+  const decoded = jws.decode(id_token);
+  if (decoded == null)
+    return self. fail(null, false, 'Invalid JWT token');
+  log.info('token decoded: ', decoded);
+
+  // get Pem Key
+  var PEMkey = undefined;
+  if (decoded.header.x5t) {
+    PEMkey = self.metadata.generateOidcPEM(decoded.header.x5t);
+  } else if (decoded.header.kid) {
+    PEMkey = self.metadata.generateOidcPEM(decoded.header.kid);
+  } else {
+    return self.fail('We did not reveive a token we know how to validate');
+  }
+
+  var options = self._options;
+
+  // since the id_token is for itself, so the id_token is the clientID by default
+  options.audience = options.clientID;
+
+  // verify id_token signature and claims
+  return jwt.verify(id_token, PEMkey, options, (err, jwtClaims) => {
+    if (err)
+      return self.fail("cannot verify id token");
+    log.info("Claims received: ", jwtClaims);
+
+    // jwt checks the 'nbf', 'exp', 'aud', 'iss' claims
+    // there are a few other things we will check below
+
+    // we don't allow multiple audiences in id_token
+    if (Array.isArray(jwtClaims.aud) && jwtClaims.aud.length > 1)
+      return self.fail('we do not allow multiple audiences in id_token');
+
+    // check the nonce in claims
+    var nonceCheckResult = nonceHandler.verifyNonce(req, self._key, jwtClaims.nonce);
+    if (!nonceCheckResult.valid)
+      return self.fail(nonceCheckResult.errorMessage);
+
+    // check c_hash
+    if (code && jwtClaims.c_hash && !utils.checkHashValueRS256(code, jwtClaims.c_hash))
+      return self.fail("invalid c_hash");
+
+    // check at_hash
+    if (access_token && jwtClaims.at_hash && !utils.checkHashValueRS256(access_token, jwtClaims.at_hash))
+      return self.fail("invalid at_hash");
+
+    // return jwt claims and jwt claims string
+    var idTokenSegments = id_token.split('.');
+    var jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
+    return callback(jwtClaimsStr, jwtClaims);
+  });
+};
+
+/**
+ * handle error response
+ *
+ * @params {String} err 
+ * @params {String} err_description
+ */
+Strategy.prototype._errorResponseHandler = function errorResponseHandler(err, err_description) {
+  const self = this;
+
+  log.info('Error received in the response was: ', err);
+  if (err_description)
+    log.info('Error description received in the response was: ', err_description);
+
+  // Unfortunately, we cannot return the 'error description' to the user, since 
+  // it goes to http header by default and it usually contains characters that
+  // http header doesn't like, which causes the program to crash. 
+  return self.fail(err);
+};
+
+/**
+ * handle the response where we only get 'id_token' in the response
+ *
+ * @params {Object} id_token 
+ * @params {Object} req
+ * @params {Function} next
+ */
+Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(id_token, req, next) {
+  /* we will do the following things in order
+   * (1) validate id_token
+   * (2) use the claims in the id_token for user's profile
+   */
+
+  const self = this;
+
+  log.info(`we are in the implicit flow, where we only got 'id_token'`);
+  log.info('received id_token: ', id_token);
+
+  // validate the id_token
+  return self._validateIdToken(id_token, null, null, req, (jwtClaimsStr, jwtClaims) => {
+    const sub = jwtClaims.sub;
+    const iss = jwtClaims.iss;
+
+    return self._shouldLoadUserProfile(iss, sub, (err, load) => {
+      if (err) {
+        return next(err);
+      }
+
+      if (load) {
+        // we do not have a userinfo endpoint for id token at the moment
+        log.warn('We do not have a userinfo endpoint for id_token, we will use the claims in id_token for the profile.');
+      }
+
+      // we are not doing auth code so we set the tokens to null
+      const accessToken = null;
+      const refreshToken = null;
+      const params = null;
+
+      // lets do an id_token fallback. We use id_token over userInfo endpoint for now
+      // log.info('PROFILE FALLBACK: Since we did not use the UserInfo endpoint, falling back to id_token for profile.');
+
+      return onProfileLoaded(self, {
+        req,
+        sub,
+        iss,
+        profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+        jwtClaims,
+        accessToken,
+        refreshToken,
+        params,
+      });
+    });
+  });
+};
+
+/**
+ * handle the response where we get 'id_token' and 'code' in the response
+ *
+ * @params {Object} id_token 
+ * @params {Object} code
+ * @params {Object} req
+ * @params {Function} next
+ */
+Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(id_token, code, req, next) {
+  /* we will do the following things in order
+   * (1) validate the id_token and the code
+   * (2) if there is no userinfo token needed (or ignored if using AAD v2 ), we use 
+   *     the claims in id_token for user's profile
+   * (3) if userinfo token is needed, we will use the 'code' and the authorization code flow
+   */
+  const self = this;
+
+  log.info(`we are in the hybrid flow, where we got 'id_token' and 'code'`);
+  log.info('received id_token: ', id_token);
+  log.info('received code: ', code);
+
+  // nonce is deleted after id_token is valiated. If we use the authorization code
+  // flow, we will get a second id_token, so we want to save the nonce and use it
+  // for the second id_token validation later. 
+  var nonce = req.session[self._key].nonce;
+
+  // save nonce, since if we use the authorization code flow later, we have to check 
+  // nonce again.
+
+  // validate the id_token and the code
+  return self._validateIdToken(id_token, code, null, req, (jwtClaimsStr, jwtClaims) => {
+    const sub = jwtClaims.sub;
+    const iss = jwtClaims.iss;
+
+    return self._shouldLoadUserProfile(iss, sub, (err, load) => {
+      if (err) {
+        return next(err);
+      }
+
+      if (load && !self._options._isV2) {
+        // since we will get a second id_token, we put nonce back into req.session
+        nonceHandler.addNonceToSession(req, self._key, nonce);
+
+        // now we use the authorization code flow
+        return self._authCodeFlowHandler(code, req, next);
+      } else {
+        // use the claims from id_token
+
+        if (load && self._options._isV2) {
+          // AAD v2 has no userinfo endpoint
+          log.warn(`Azure v2.0 does not have a 'userinfo' endpoint, we will use the claims in id_token for the profile.`);
+        }
+
+        // we are not doing auth code so we set the tokens to null
+        const accessToken = null;
+        const refreshToken = null;
+        const params = null;
+
+        return onProfileLoaded(self, {
+          req,
+          sub,
+          iss,
+          profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+          jwtClaims,
+          accessToken,
+          refreshToken,
+          params,
+        });
+     }
+    });
+  });
+};
+
+/**
+ * handle the response where we only get 'code' in the response
+ *
+ * @params {Object} code
+ * @params {Object} req
+ * @params {Function} next
+ */
+Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(code, req, next) {
+  /* we will do the following things in order:
+   * (1) use code to get id_token and access_token
+   * (2) validate the id_token and the access_token received
+   * (3) if user asks for userinfo and we are using AAD v1, then we use access_token to get
+   *     userinfo, then make sure the userinfo has the same 'sub' as that in the 'id_token'
+   */
+  const self = this;
+
+  log.info(`we are in the authorization code flow, where we only got 'code'`);
+  log.info('received code: ', code);
+
+  // use `null` as identifier since we are in the callback phase of OAuth 2.0 Dance already
+  // identifier only has impact on the `authorize` endpoint
+  return self.configure(null, (err, config) => {
+    if (err) {
+      return next(err);
+    }
+
+    const oauth2 = new OAuth2(
+      config.clientID, // consumerKey
+      config.clientSecret, // consumer secret
+      '', // baseURL (empty string because we use absolute urls for authorize and token paths)
+      config.authorizationURL, // authorizePath
+      config.tokenURL, // accessTokenPath
+      {} // customHeaders
+    );
+
+    let callbackURL = config.callbackURL;
+    // options.callbackURL is merged into config object while `setOptions` call
+    if (!callbackURL) {
+      return next(new Error('no callbackURL found'));
+    }
+
+    const parsedCallbackURL = url.parse(callbackURL);
+    if (!parsedCallbackURL.protocol) {
+      // The callback URL is relative, resolve a fully qualified URL from the
+      // URL of the originating request.
+      callbackURL = url.resolve(utils.originalURL(req), callbackURL);
+    }
+
+    return oauth2.getOAuthAccessToken(code, {
+      grant_type: 'authorization_code',
+      redirect_uri: callbackURL,
+      }, (getOAuthAccessTokenError, access_token, refresh_token, params) => {
+        if (getOAuthAccessTokenError) {
+          return next(new InternalOAuthError('failed to obtain access token', getOAuthAccessTokenError));
+        }
+
+        var id_token = params.id_token;
+
+        // id_token should be present
+        if (!id_token)
+          return self.fail('id_token is not received');
+        // token_type must be 'Bearer'
+        if (params.token_type !== 'Bearer') {
+          log.info('token_type received is: ', params.token_type);
+          return self.fail(`token_type received is not 'Bearer'`);
+        }
+
+        log.info('received id_token: ', id_token);
+
+        return self._validateIdToken(id_token, null, access_token, req, (jwtClaimsStr, jwtClaims) => {
+          const sub = jwtClaims.sub;
+          const iss = jwtClaims.iss;
+
+          return self._shouldLoadUserProfile(iss, sub, (shouldLoadUserProfileError, load) => {
+            if (shouldLoadUserProfileError) {
+              return next(shouldLoadUserProfileError);
+            }
+
+            if (load && self._options._isV2) {
+              log.warn(`Azure v2.0 does not have a 'userinfo' endpoint, we will use the claims in id_token for the profile.`)
+            } else if (load) {
+              // make sure we get an access_token
+              if (!access_token)
+                return self.fail("we want to access userinfo endpoint, but access_token is not received");
+
+              let parsedUrl;
+              try {
+                parsedUrl = url.parse(config.userInfoURL, true);
+              } catch (urlParseException) {
+                return next(
+                  new InternalOpenIDError(
+                    `Failed to parse config property 'userInfoURL' with value ${config.userInfoURL}`,
+                    urlParseException
+                  )
+                );
+              }
+
+              parsedUrl.query.schema = 'openid';
+              delete parsedUrl.search; // delete operations are slow; should we rather just overwrite it with {}
+              const userInfoURL = url.format(parsedUrl);
+
+              // ask oauth2 to use authorization header to bearer access token
+              oauth2.useAuthorizationHeaderforGET(true);
+              return oauth2.get(userInfoURL, access_token, (getUserInfoError, body) => {
+                if (getUserInfoError) {
+                  return next(new InternalOAuthError('failed to fetch user profile', getUserInfoError));
+                }
+
+                log.info('PROFILE LOADED FROM MS IDENTITY', body);
+
+                var userinfoReceived = undefined;
+                // use try / catch around JSON.parse --> could fail unexpectedly
+                try {
+                  userinfoReceived = JSON.parse(body);
+                } catch (ex) {
+                  return next(ex);
+                }
+
+                // make sure the 'sub' in userinfo is the same as the one in 'id_token'
+                if (userinfoReceived.sub !== jwtClaims.sub) {
+                  log.error('sub in userinfo is ' + userinfoReceived.sub + ', but does not match sub in id_token, which is ' + id_token.sub);
+                  return self.fail('sub received in userinfo and id_token do not match');
+                }
+
+                return onProfileLoaded(self, {
+                  req,
+                  sub,
+                  iss,
+                  profile: makeProfileObject(userinfoReceived, body),
+                  jwtClaims,
+                  access_token,
+                  refresh_token,
+                  params,
+                });
+              });
+            }
+
+            // lets do an id_token fallback. We use id_token over userInfo endpoint for now
+            return onProfileLoaded(self, {
+              req,
+              sub,
+              iss,
+              profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+              jwtClaims,
+              access_token,
+              refresh_token,
+              params,
+            });
+          });
+        });
+      });
+  });
+};
+
+/**
+ * prepare the initial authorization request
+ *
+ * @params {Object} req
+ * @params {Function} next
+ */
+Strategy.prototype._flowInitializationHandler = function flowInitializationHandler(req, next) {
+  // The request being authenticated is initiating OpenID Connect
+  // authentication. Prior to redirecting to the provider, configuration will
+  // be loaded. The configuration is typically either pre-configured or
+  // discovered dynamically. When using dynamic discovery, a user supplies
+  // their identifer as input.
+
+  const self = this;
+
+  log.info(`we are in the OpenID Connect Inital Flow`);
+
+  let identifier;
+  if (req.body && req.body[this._identifierField]) {
+    identifier = req.body[this._identifierField];
+  } else if (req.query && req.query[this._identifierField]) {
+    identifier = req.query[this._identifierField];
+  }
+
+  return self.configure(identifier, (configureError, config) => {
+    if (configureError) {
+      return next(configureError);
+    }
+
+    var options = self._options;
+
+    let callbackURL = options.callbackURL || config.callbackURL;
+    if (callbackURL) {
+      const parsed = url.parse(callbackURL);
+      if (!parsed.protocol) {
+        // The callback URL is relative, resolve a fully qualified URL from the
+        // URL of the originating request.
+        callbackURL = url.resolve(utils.originalURL(req), callbackURL);
+      }
+    }
+
+    log.info('Going in with our config loaded as: ', config);
+
+    const params = {};
+    if (self.authorizationParams) {
+      _.assign(params, self.authorizationParams(options));
+    }
+    _.assign(params, {
+      redirect_uri: callbackURL,
+    }, objectTransform({
+      source: config,
+      map: {
+        responseMode: 'response_mode',
+        responseType: 'response_type',
+        clientID: 'client_id',
+        resourceURL: 'resource',
+      },
+    }));
+
+    log.info('We are sending the response_type: ', params.response_type);
+    log.info('We are sending the response_mode: ', params.response_mode);
+
+    let scope = config.scope;
+    if (Array.isArray(scope)) {
+      scope = scope.join(config.scopeSeparator);
+    }
+    if (scope) {
+      params.scope = ['openid', scope].join(config.scopeSeparator);
+    } else {
+      params.scope = 'openid';
+    }
+
+    // if (policy) { params['p'] = policy; }; // Policy parameter should be included.
+
+    // add state to params and session, use the given one or generate one
+    let state = params.state = options.state || utils.uid(24);
+    stateHandler.addStateToSession(req, self._key, state);
+
+    // add nonce, use a randomly generated one
+    let nonce = params.nonce = utils.uid(16);
+    nonceHandler.addNonceToSession(req, self._key, nonce);
+
+    let location;
+
+    // Implement support for standard OpenID Connect params (display, prompt, etc.)
+
+    if (req.query.p) {
+      location = `${config.authorizationURL}&${querystring.stringify(params)}`;
+    } else {
+      location = `${config.authorizationURL}?${querystring.stringify(params)}`;
+    }
+
+    return self.redirect(location);
+  });
+}
 
 module.exports = Strategy;

--- a/lib/stateHandler.js
+++ b/lib/stateHandler.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ 
+'use strict';
+
+exports.verifyState = function(req, sessionKey) {
+	if (!req.session) {
+		return {valid: false, errorMessage: 'OIDC strategy requires session support. Did you forget to use express-session middleware?'};
+	}
+
+	// returned state may be in the body or query
+	var state_returned = undefined;
+	if (req.query && req.query.state)
+		state_returned = req.query.state;
+	else if (req.body && req.body.state)
+		state_returned = req.body.state;
+
+	if (!state_returned) {
+		return {valid: false, errorMessage: 'state is not found in the request'};
+	}
+
+	// the state we provided before should be in req.session[sessionKey]
+	var state_provided = req.session[sessionKey] && req.session[sessionKey].state;
+	if (!state_provided)
+		return {valid: false, errorMessage: 'state was not provided'};
+
+	// clear the state saved in session, and clear the session if there is nothing inside
+	delete req.session[sessionKey].state;
+	if (Object.keys(req.session[sessionKey]).length ===0)
+		delete req.session[sessionKey];
+
+	// compare the two states
+	if (state_returned !== state_provided)
+		return {valid:false, errorMessage: 'invalid state in the request'};
+
+	return {valid: true, errorMessage: ''};
+};
+
+exports.addStateToSession = function(req, sessionKey, state) {
+	if (!req.session) {
+		return {valid: false, errorMessage: 'OIDC strategy requires session support. Did you forget to use express-session middleware?'};
+	}
+	if (!req.session[sessionKey])
+		req.session[sessionKey] = {};
+	req.session[sessionKey].state = state;
+}

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -72,9 +72,9 @@ types.isTypeLegal = {
 Validator.isModeLegal = 'isModeLegal';
 types.isModeLegal = {
   validate: (value) => {
-    return value === 'query' || value === 'form_post';
+    return value === 'form_post';
   },
-  error: 'The responseMode: must be either query or form_post.',
+  error: 'The responseMode: must be form_post.',
 };
 
 Validator.isURL = 'isURL';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "base64url": "^2.0.0",
     "bunyan": "^1.8.0",
     "cache-manager": "^2.0.0",
     "jsonwebtoken": "^6.2.0",

--- a/test/Chai-passport_test/oidc_error_and_state_test.js
+++ b/test/Chai-passport_test/oidc_error_and_state_test.js
@@ -62,34 +62,25 @@ testStrategy.configure = function(identifier, done) {
 
 // Mock `setOptions`
 // `setOptions` is used to read and save the metadata, we don't need this in test 
-testStrategy.setOptions = function(options, metadata, next) { return next();};
+testStrategy.setOptions = function(options, metadata, cachekey, next) { return next();};
 
 
 describe('OIDCStrategy error handling', function() {
   var challenge;
   var err = {error: 'my_error', error_description: 'my_error_description'};
 
-  var put_err_in_query = function(req) { req.query = err; }
-  var put_err_in_body = function(req) { req.query = {}; req.body = err; }
-
-  var testPrepare = function(put_err_callback) {
+  var testPrepare = function() {
   	return function(done) {
   		chai.passport
   		  .use(testStrategy)
   		  .fail(function(c) { challenge = c; done(); })
-  		  .req(function(req) { put_err_callback(req); })
+  		  .req(function(req) { req.session = { 'my_key' : {state: 'my_state'}}; req.query = { state: 'my_state'}; req.body = err; })
   		  .authenticate({});
   	};
   };
 
-  describe('error in query', function() {
-  	before(testPrepare(put_err_in_query));
-
-  	it('should call fail function', function() { chai.expect(challenge).to.equal('my_error'); });
-  });
-
   describe('error in body', function() {
-    before(testPrepare(put_err_in_body));
+    before(testPrepare());
 
     it('should call fail function', function() { chai.expect(challenge).to.equal('my_error'); });
   });


### PR DESCRIPTION
Breaking change: response_type = 'query' is not longer allowed, since according to the openid spec, query must not be used for hybrid and implicit flow. Now we uniformly use response_type = 'form_post'.

Added:
(1) id_token and nonce validation
(2) code, c_hash validation
(3) access_token, at_hash validation
(4) state validation