### PR TITLE
remove _shouldLoadUserProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-<a name="2.0.1"></a>
+<a name="3.0.0"></a>
+# 3.0.0
+
+## Breaking changes from 2.0.1
+
+### OIDCStrategy
+* skipUserProfile option is no longer provided. We will load 'userinfo' if AAD v1 is being used and
+if there is 'code' involved in the flow (in other words, one of the following flows: 'code', 
+'code id_token', 'id_token code'). For all other scenarios, we do an 'id_token' fallback, since we 
+cannot obtain 'userinfo' (AAD v2 doesn't have an userinfo endpoint, and 'id_token' flow doesn't yield
+ an 'access_token' to exchange for an 'userinfo' token).
+
 # 2.0.1
 
 ## Major changes from 2.0.0

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -140,8 +140,6 @@ function onProfileLoaded(strategy, args) {
  *   - `identityMetadata`   the metadata endpoint provided by the Microsoft Identity Portal that provides 
  *                          the keys and other important info at runtime. We roll keys frequently, so don't
  *                          override this to supply your own.
- *   - `skipUserProfile`    Microsoft Identity platform doesn't support a userinfo endpoint yet, so we should 
- *                          skip loading a profile from it.
  *   - `responseType`       for login only flows use id_token. For accessing resources use `id_token code`
  *   - `responseMode`       For login only flows we should have token passed back to us in a POST
  *   - `validateIssuer`     if you have validation on, you cannot have users from multiple tenants sign in
@@ -155,7 +153,6 @@ function onProfileLoaded(strategy, args) {
  *   scope: config.creds.scopes,
  *   clientID: config.creds.clientID,
  *   identityMetadata: config.creds.identityMetadata,
- *   skipUserProfile: config.creds.skipUserProfile,
  *   responseType: config.creds.responseType,
  *   responseMode: config.creds.responseMode,
  *   validateIssuer: config.creds.validateIssuer,
@@ -191,7 +188,6 @@ function Strategy(options, verify) {
   this._options = options;
   this.name = 'azuread-openidconnect';
   this._verify = verify;
-  this._options.skipUserProfile = !!options.skipUserProfile;
   this._passReqToCallback = !!options.passReqToCallback;
 
   /* When a user is authenticated for the first time, passport adds a new field
@@ -730,17 +726,12 @@ Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(id_token,
     const sub = jwtClaims.sub;
     const iss = jwtClaims.iss;
     
-    // we don't load userinfo unless user set skipUserProfile to false
-    const load = (self._options.skipUserProfile === false);
-    if (load) {
-      // we do not have a userinfo endpoint for id token at the moment
-      log.warn('We do not have a userinfo endpoint for id_token, we will use the claims in id_token for the profile.');
-    }
-
     // we are not doing auth code so we set the tokens to null
     const access_token = null;
     const refresh_token = null;
     const params = null;
+
+    log.info('we are in implicit flow, use the content in id_token as the profile');
 
     return onProfileLoaded(self, {
       req,
@@ -889,13 +880,9 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(code, req
 
       const sub = jwtClaims.sub;
       const iss = jwtClaims.iss;
-
-      // we don't load userinfo unless user set skipUserProfile to false
-      const load = (self._options.skipUserProfile === false);
       
-      if (load && self._options._isV2) {
-        log.warn(`Azure v2.0 does not have a 'userinfo' endpoint, we will use the claims in id_token for the profile.`)
-      } else if (load) {
+      // load the userinfo if this is not v2
+      if (!self._options._isV2) {
         // make sure we get an access_token
         if (!access_token)
           return self.fail("we want to access userinfo endpoint, but access_token is not received");
@@ -950,19 +937,21 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(code, req
             params,
           });
         });
-      }
+      } else {
+        // v2 doesn't have userinfo endpoint, so we use the content in id_token as the profile
+        log.info('v2 has no userinfo endpoint, using the content in id_token as the profile');
 
-      // lets do an id_token fallback. We use id_token over userInfo endpoint for now
-      return onProfileLoaded(self, {
-        req,
-        sub,
-        iss,
-        profile: makeProfileObject(jwtClaims, jwtClaimsStr),
-        jwtClaims,
-        access_token,
-        refresh_token,
-        params,
-      });
+        return onProfileLoaded(self, {
+          req,
+          sub,
+          iss,
+          profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+          jwtClaims,
+          access_token,
+          refresh_token,
+          params,
+        });
+      }
     });
   });
 };

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -605,28 +605,6 @@ Strategy.prototype.setOptions = function setOptions(options, metadataUrl, cachek
 };
 
 /**
- * Check if should load user profile, contingent upon options.
- *
- * @param {String} issuer
- * @param {String} subject
- * @param {Function} done
- * @api private
- */
-Strategy.prototype._shouldLoadUserProfile = function shouldLoadUserProfile(issuer, subject, done) {
-  var skipUserProfile = this._options.skipUserProfile;
-  // check if _skipUserProfile is an async function (expexts more than 2 arguments)
-  if (typeof skipUserProfile === 'function' && skipUserProfile.length > 2) {
-    return skipUserProfile(issuer, subject, (err, skip) => {
-      return done(err, !skip);
-    });
-  }
-  const skip = (typeof skipUserProfile === 'function') ?
-    skipUserProfile(issuer, subject) :
-    skipUserProfile;
-  return done(null, !skip);
-};
-
-/**
  * validate id_token, and pass the validated claims and the payload to callback
  * if code (resp. access_token) is provided, we will validate the c_hash (resp at_hash) as well
  *
@@ -751,35 +729,28 @@ Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(id_token,
   return self._validateResponse(id_token, null, null, req, (jwtClaimsStr, jwtClaims) => {
     const sub = jwtClaims.sub;
     const iss = jwtClaims.iss;
+    
+    // we don't load userinfo unless user set skipUserProfile to false
+    const load = (self._options.skipUserProfile === false);
+    if (load) {
+      // we do not have a userinfo endpoint for id token at the moment
+      log.warn('We do not have a userinfo endpoint for id_token, we will use the claims in id_token for the profile.');
+    }
 
-    return self._shouldLoadUserProfile(iss, sub, (err, load) => {
-      if (err) {
-        return next(err);
-      }
+    // we are not doing auth code so we set the tokens to null
+    const access_token = null;
+    const refresh_token = null;
+    const params = null;
 
-      if (load) {
-        // we do not have a userinfo endpoint for id token at the moment
-        log.warn('We do not have a userinfo endpoint for id_token, we will use the claims in id_token for the profile.');
-      }
-
-      // we are not doing auth code so we set the tokens to null
-      const access_token = null;
-      const refresh_token = null;
-      const params = null;
-
-      // lets do an id_token fallback. We use id_token over userInfo endpoint for now
-      // log.info('PROFILE FALLBACK: Since we did not use the UserInfo endpoint, falling back to id_token for profile.');
-
-      return onProfileLoaded(self, {
-        req,
-        sub,
-        iss,
-        profile: makeProfileObject(jwtClaims, jwtClaimsStr),
-        jwtClaims,
-        access_token,
-        refresh_token,
-        params,
-      });
+    return onProfileLoaded(self, {
+      req,
+      sub,
+      iss,
+      profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+      jwtClaims,
+      access_token,
+      refresh_token,
+      params,
     });
   });
 };
@@ -821,17 +792,11 @@ Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(id_token, cod
     const sub = jwtClaims.sub;
     const iss = jwtClaims.iss;
 
-    return self._shouldLoadUserProfile(iss, sub, (err, load) => {
-      if (err) {
-        return next(err);
-      }
+    // since we will get a second id_token, we put nonce back into req.session
+    nonceHandler.addNonceToSession(req, self._key, nonce);
 
-      // since we will get a second id_token, we put nonce back into req.session
-      nonceHandler.addNonceToSession(req, self._key, nonce);
-
-      // now we use the authorization code flow
-      return self._authCodeFlowHandler(code, req, next, iss, sub);
-    });
+    // now we use the authorization code flow
+    return self._authCodeFlowHandler(code, req, next, iss, sub);
   });
 };
 
@@ -925,81 +890,78 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(code, req
       const sub = jwtClaims.sub;
       const iss = jwtClaims.iss;
 
-      return self._shouldLoadUserProfile(iss, sub, (shouldLoadUserProfileError, load) => {
-        if (shouldLoadUserProfileError) {
-          return next(shouldLoadUserProfileError);
+      // we don't load userinfo unless user set skipUserProfile to false
+      const load = (self._options.skipUserProfile === false);
+      
+      if (load && self._options._isV2) {
+        log.warn(`Azure v2.0 does not have a 'userinfo' endpoint, we will use the claims in id_token for the profile.`)
+      } else if (load) {
+        // make sure we get an access_token
+        if (!access_token)
+          return self.fail("we want to access userinfo endpoint, but access_token is not received");
+
+        let parsedUrl;
+        try {
+          parsedUrl = url.parse(config.userInfoURL, true);
+        } catch (urlParseException) {
+          return next(
+            new InternalOpenIDError(
+              `Failed to parse config property 'userInfoURL' with value ${config.userInfoURL}`,
+              urlParseException
+            )
+          );
         }
 
-        if (load && self._options._isV2) {
-          log.warn(`Azure v2.0 does not have a 'userinfo' endpoint, we will use the claims in id_token for the profile.`)
-        } else if (load) {
-          // make sure we get an access_token
-          if (!access_token)
-            return self.fail("we want to access userinfo endpoint, but access_token is not received");
+        parsedUrl.query.schema = 'openid';
+        delete parsedUrl.search; // delete operations are slow; should we rather just overwrite it with {}
+        const userInfoURL = url.format(parsedUrl);
 
-          let parsedUrl;
-          try {
-            parsedUrl = url.parse(config.userInfoURL, true);
-          } catch (urlParseException) {
-            return next(
-              new InternalOpenIDError(
-                `Failed to parse config property 'userInfoURL' with value ${config.userInfoURL}`,
-                urlParseException
-              )
-            );
+        // ask oauth2 to use authorization header to bearer access token
+        oauth2.useAuthorizationHeaderforGET(true);
+        return oauth2.get(userInfoURL, access_token, (getUserInfoError, body) => {
+          if (getUserInfoError) {
+            return next(new InternalOAuthError('failed to fetch user profile', getUserInfoError));
           }
 
-          parsedUrl.query.schema = 'openid';
-          delete parsedUrl.search; // delete operations are slow; should we rather just overwrite it with {}
-          const userInfoURL = url.format(parsedUrl);
+          log.info('Profile loaded from MS identity', body);
 
-          // ask oauth2 to use authorization header to bearer access token
-          oauth2.useAuthorizationHeaderforGET(true);
-          return oauth2.get(userInfoURL, access_token, (getUserInfoError, body) => {
-            if (getUserInfoError) {
-              return next(new InternalOAuthError('failed to fetch user profile', getUserInfoError));
-            }
+          var userinfoReceived = null;
+          // use try / catch around JSON.parse --> could fail unexpectedly
+          try {
+            userinfoReceived = JSON.parse(body);
+          } catch (ex) {
+            return next(ex);
+          }
 
-            log.info('Profile loaded from MS identity', body);
+          // make sure the 'sub' in userinfo is the same as the one in 'id_token'
+          if (userinfoReceived.sub !== jwtClaims.sub) {
+            log.error('sub in userinfo is ' + userinfoReceived.sub + ', but does not match sub in id_token, which is ' + id_token.sub);
+            return self.fail('sub received in userinfo and id_token do not match');
+          }
 
-            var userinfoReceived = null;
-            // use try / catch around JSON.parse --> could fail unexpectedly
-            try {
-              userinfoReceived = JSON.parse(body);
-            } catch (ex) {
-              return next(ex);
-            }
-
-            // make sure the 'sub' in userinfo is the same as the one in 'id_token'
-            if (userinfoReceived.sub !== jwtClaims.sub) {
-              log.error('sub in userinfo is ' + userinfoReceived.sub + ', but does not match sub in id_token, which is ' + id_token.sub);
-              return self.fail('sub received in userinfo and id_token do not match');
-            }
-
-            return onProfileLoaded(self, {
-              req,
-              sub,
-              iss,
-              profile: makeProfileObject(userinfoReceived, body),
-              jwtClaims,
-              access_token,
-              refresh_token,
-              params,
-            });
+          return onProfileLoaded(self, {
+            req,
+            sub,
+            iss,
+            profile: makeProfileObject(userinfoReceived, body),
+            jwtClaims,
+            access_token,
+            refresh_token,
+            params,
           });
-        }
-
-        // lets do an id_token fallback. We use id_token over userInfo endpoint for now
-        return onProfileLoaded(self, {
-          req,
-          sub,
-          iss,
-          profile: makeProfileObject(jwtClaims, jwtClaimsStr),
-          jwtClaims,
-          access_token,
-          refresh_token,
-          params,
         });
+      }
+
+      // lets do an id_token fallback. We use id_token over userInfo endpoint for now
+      return onProfileLoaded(self, {
+        req,
+        sub,
+        iss,
+        profile: makeProfileObject(jwtClaims, jwtClaimsStr),
+        jwtClaims,
+        access_token,
+        refresh_token,
+        params,
       });
     });
   });

--- a/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
@@ -62,7 +62,6 @@ var options = {
   callbackURL: 'http://localhost:3000/auth/openid/return',
   clientID: '2abf3a52-7d86-460b-a1ef-77dc43de8aad',
   identityMetadata: 'https://login.microsoftonline.com/sijun.onmicrosoft.com/.well-known/openid-configuration',
-  skipUserProfile: true,
   responseType: 'id_token code',
   responseMode: 'form_post',
   validateIssuer: true,
@@ -90,7 +89,6 @@ var setIgnoreExpirationFalse = function(options) { options.ignoreExpiration = fa
 var setWrongIssuer = function(options) { options.oidcIssuer = 'wrong_issuer'; };
 var rmValidateIssuer = function(options) { options.validateIssuer = undefined; };
 var setWrongAudience = function(options) { options.audience = 'wrong audience'; };
-var setSkipUserProfileFalse = function(options) { options.skipUserProfile = false; };
 
 var testStrategy = new OIDCStrategy(options, function(profile, done) {
     done(null, profile.email);
@@ -292,7 +290,7 @@ describe('OIDCStrategy hybrid flow test', function() {
 
   describe('success', function() {
     before(setReqFromAuthRespRedirect(id_token_in_auth_resp, code, nonce, 
-      [resetOptions, setTokenResponse(id_token_in_token_resp, access_token), setSkipUserProfileFalse]));
+      [resetOptions, setTokenResponse(id_token_in_token_resp, access_token)]));
 
     it('should succeed with expected user', function() {
       chai.expect(user).to.equal('robot@sijun.onmicrosoft.com');
@@ -301,7 +299,7 @@ describe('OIDCStrategy hybrid flow test', function() {
 
   describe('fail: missing access_token', function() {
     before(setReqFromAuthRespRedirect(id_token_in_auth_resp, code, nonce, 
-      [resetOptions, setTokenResponse(id_token_in_token_resp, null), setSkipUserProfileFalse]));
+      [resetOptions, setTokenResponse(id_token_in_token_resp, null)]));
 
     it('should fail with access_token missing', function() {
       chai.expect(challenge).to.equal('we want to access userinfo endpoint, but access_token is not received');
@@ -311,7 +309,7 @@ describe('OIDCStrategy hybrid flow test', function() {
   describe('fail: invalid sub in userinfo', function() {
     before(setReqFromAuthRespRedirect(id_token_in_auth_resp, code, nonce, 
       [resetOptions, setTokenResponse(id_token_in_token_resp, access_token), 
-        setUserInfoResponse('use_invalid_sub'), setSkipUserProfileFalse]));
+        setUserInfoResponse('use_invalid_sub')]));
 
     it('should fail with invalid sub in userInfo', function() {
       chai.expect(challenge).to.equal('sub received in userinfo and id_token do not match');
@@ -393,7 +391,7 @@ describe('OIDCStrategy authorization code flow test', function() {
 
   describe('success', function() {
     before(setReqFromAuthRespRedirect(null, code, nonce, 
-      [resetOptions, setTokenResponse(id_token_in_token_resp, access_token), setSkipUserProfileFalse]));
+      [resetOptions, setTokenResponse(id_token_in_token_resp, access_token)]));
 
     it('should succeed with expected user', function() {
       chai.expect(user).to.equal('robot@sijun.onmicrosoft.com');
@@ -402,7 +400,7 @@ describe('OIDCStrategy authorization code flow test', function() {
 
   describe('fail: access_token is not received', function() {
     before(setReqFromAuthRespRedirect(null, code, nonce, 
-      [resetOptions, setTokenResponse(id_token_in_token_resp, null), setSkipUserProfileFalse]));
+      [resetOptions, setTokenResponse(id_token_in_token_resp, null)]));
 
     it('should fail with access_token missing', function() {
       chai.expect(challenge).to.equal('we want to access userinfo endpoint, but access_token is not received');
@@ -412,7 +410,7 @@ describe('OIDCStrategy authorization code flow test', function() {
   describe('fail: invalid sub in userinfo', function() {
     before(setReqFromAuthRespRedirect(null, code, nonce, 
       [resetOptions, setTokenResponse(id_token_in_token_resp, access_token), 
-        setUserInfoResponse('use_invalid_sub'), setSkipUserProfileFalse]));
+        setUserInfoResponse('use_invalid_sub')]));
 
     it('should fail with invalid sub in userInfo', function() {
       chai.expect(challenge).to.equal('sub received in userinfo and id_token do not match');

--- a/test/Chai-passport_test/oidc_implicit_flow_test.js
+++ b/test/Chai-passport_test/oidc_implicit_flow_test.js
@@ -56,7 +56,6 @@ var options = {
   callbackURL: 'http://localhost:3000/auth/openid/return',
   clientID: '2abf3a52-7d86-460b-a1ef-77dc43de8aad',
   identityMetadata: 'https://login.microsoftonline.com/sijun.onmicrosoft.com/.well-known/openid-configuration',
-  skipUserProfile: true,
   responseType: 'id_token',
   responseMode: 'form_post',
   validateIssuer: true,

--- a/test/Chai-passport_test/oidc_incoming_request_test.js
+++ b/test/Chai-passport_test/oidc_incoming_request_test.js
@@ -37,7 +37,6 @@ var options = {
     clientID: 'my_client_id',
     clientSecret: 'my_client_secret',
     identityMetadata: 'https://login.microsoftonline.com/xxx.onmicrosoft.com/.well-known/openid-configuration',
-    skipUserProfile: true,
     responseType: 'id_token',
     responseMode: 'form_post',
     validateIssuer: true,


### PR DESCRIPTION
This function assumes options.skipUserProfile can be a function, this is impossible since options.skipUserProfile is read from the config file, it can only be true or false. So let's remove this dead code.

For any code like:

```
self._shouldLoadUserProfile(iss, sub, (err, load) => {
     if (err)
        err_handling_logic;
     callback_function_body;
   }
);
```

We don't need _shouldLoadUserProfile to decide if we want to load user profile, so remove the _shouldLoadUserProfile and transform it to
```
 // we don't load userinfo unless user set skipUserProfile to false
const load = (self._options.skipUserProfile === false);

callback_function_body;
```


