### PR TITLE
Fix xpath expression in validateSignature

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -215,7 +215,7 @@ SAML.prototype.getLogoutUrl = function getLogoutUrl(req, callback) {
 
 SAML.prototype.validateSignature = function validSignature(xml, cert) {
   const doc = new xmldom.DOMParser().parseFromString(xml);
-  const xpathExpression = '//*[local-name(.)="Signature" and namespace-uri(.)="http: //www.w3.org/2000/09/xmldsig#"]';
+  const xpathExpression = '//*[local-name(.)="Signature" and namespace-uri(.)="http://www.w3.org/2000/09/xmldsig#"]';
   const signature = xmlCrypto.xpath(doc, xpathExpression)[0];
   const sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {


### PR DESCRIPTION
We spot a bug in `passport-azure-ad` 2 (it affects all versions from 2.0.0 to 2.0.3).

In 0ac89df8679e9e0a2744ccc0de81a620f914a1b8, the `validateSignature` function has been rewritten and a typo on the namespace URI was made: `http://www.w3.org/2000/09/xmldsig#` became `http: //www.w3.org/2000/09/xmldsig#` (notice the extra whitespace added after `http:`).

This change broke the `validateSignature` function. The line `sig.loadSignature(signature.toString());` would always yield a `Cannot read property 'toString' of undefined` message.
