### PR TITLE
Search for e-mail & break-up displayName if individual names not set

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -70,18 +70,62 @@ const NONCE_LIFE_TIME = 3600; // second
 // B2C policy is like 'b2c_1_policyname'. policy is not case sensitive. 
 const B2C_PREFIX = 'b2c_1_';
 
+/**
+ * validateEmail - Takes an incoming string and returns true if its a valid e-mail or false if it is not.
+ * @param email the e-mail
+ * @returns {boolean} - True if its a valid email syntax, false if it is not.
+ */
+function validateEmail(email) {
+  var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(email);
+}
+
+/**
+ * splitDisplayName - Takes a displayName and splits it into First, Middle, Last.
+ * @param displayName - An entire name as one string.
+ * @returns {*} - An array of size 3, 0 = First Name, 1=Middle Name, 2=Last Name
+ */
+function splitDisplayName(displayName){
+  if(!displayName)//If displayName not set, return all undefines
+    return [undefined, undefined, undefined];
+
+  var names = displayName.trim().split(/ +/);
+
+  switch(names.length){
+    case 1://1 & 3 are same, since with 1, names[1], names[2] will be undefined
+    case 3:
+      return [names[0], names[1], names[2]];
+    case 2://If only 2 its firstname/lastname
+      return [names[0], undefined, names[1]];
+    default://Anything else, assume first name is the long one.
+      var lname = names.pop();
+      var mname = names.pop();
+      return [names.join(' '), mname, lname];
+  }
+}
+
 function makeProfileObject(src, raw) {
+  //Default the E-mail if Standard Location Not Set
+  var emails = (src.emails) ? src.emails : undefined;
+  emails = (!emails && validateEmail(src.upn)) ? [{ value: src.upn }] : undefined;
+  emails = (!emails && validateEmail(src.preferred_username)) ? [{ value : src.preferred_username }] : undefined;
+
+  //If none of name details are set, Default name values based on displayName
+  var names = (!src.family_name && !src.middle_name && !src.given_name) ?
+      splitDisplayName(src.name) : [src.family_name, src.middle_name, src.given_name];
+
   return {
     sub: src.sub,
     oid: src.oid,
     upn: src.upn,
     displayName: src.name,
+    username: src.username || src.preferred_username,
     name: {
-      familyName: src.family_name,
-      givenName: src.given_name,
-      middleName: src.middle_name,
+      familyName: names[0],
+      middleName: names[1],
+      givenName: names[2],
     },
-    emails: src.emails,
+    emails: emails,
     _raw: raw,
     _json: src,
   };


### PR DESCRIPTION
The following pull request defaults the e-mail address and name fields based on results common in an Azure AD response. This allows for a more expected result when working with Passport utilizing the standard fields used by other Passport modules.

Fixes #232  , Fixes #174 