### PR TITLE
Issue #239 Problems with signin in the updated sample

### DIFF
--- a/lib/jsonWebToken.js
+++ b/lib/jsonWebToken.js
@@ -188,7 +188,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   if (payload.nbf) {
     if (typeof payload.nbf !== 'number')
       return done(new Error('invalid nbf value in payload'));
-    if (payload.nbf > Math.floor(Date.now() / 1000))
+    if (payload.nbf > Math.ceil(Date.now() / 1000))
       return done(new Error('jwt is not active'));
   }
 


### PR DESCRIPTION
AAD rounds the current time up to the nearest integer for the nbf value, but we round the current time down when we validate the nbf value. This fails the authentication because we thought the current time is before nbf and the token is not active yet.