### PR TITLE
Issue #248 End_to_end_test showing up in test folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 <a name="3.0.1"></a>
+# 3.0.3
+
+## Bug fixes
+
+* [#248](https://github.com/AzureAD/passport-azure-ad/issues/248) End_to_end_test showing up in test folder
+
 # 3.0.2
 
 ## Changes

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and with [Microsoft Active Directory Federation Services](http://en.wikipedia.or
 _passport-azure-ad_ has a known security vulnerability affecting versions <1.4.6 and 2.0.0. Please update to >=1.4.6 or >=2.0.1 immediately. For more details, see the [security notice](https://github.com/AzureAD/passport-azure-ad/blob/master/SECURITY-NOTICE.MD).
 
 ## 2. Versions
-Current version - 3.0.2  
+Current version - 3.0.3  
 Minimum  recommended version - 1.4.6  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/passport-azure-ad/blob/master/CHANGELOG.md).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-azure-ad",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "keywords": [
     "saml",


### PR DESCRIPTION
v3.0.2 npm package has this issue. We update the version and re-publish the package.

v3.0.2 npm package contains an End_to_end_test folder, but master branch doesn't have it.
This is due to a git bug. End_to_end_test folder is in sijliu/MQ branch, if I open
passport-azure-ad in sublime, modify some files in End_to_end_test, then do a
"git reset --hard" and switch back to the master branch, then the End_to_end_test folder
will show up in the local master branch. This git behavior is incorrect, that folder
should not show up.

Even though that folder shows up, if I do a 'git status', it says the local master is the
same as the remote master branch, so git doesn't recognize it. However when I do a npm
publish, npm considers the End_to_end_test folder part of the master branch, and this
causes the diffference between the master branch and the v3.0.2 npm package.

This suggests that when we do a npm publish, we should always make a fresh clone from
github and publish there. Switching branch using git sometimes yields unexpected results.