### PR TITLE
in the bearerstrategy jwtVerify function, self.passReqToCallback was …

### DIFF
--- a/lib/bearerstrategy.js
+++ b/lib/bearerstrategy.js
@@ -293,7 +293,7 @@ Strategy.prototype.jwtVerify = function jwtVerifyFunc(req, token, metadata, opti
 
     log.info('In Strategy.prototype.jwtVerify: VerifiedToken: ', verifiedToken);
     
-    if (self.passReqToCallback) {
+    if (self._options.passReqToCallback) {
       log.info('In Strategy.prototype.jwtVerify: We did pass Req back to Callback');
       return self._verify(req, verifiedToken, done);
     } else {
@@ -301,7 +301,7 @@ Strategy.prototype.jwtVerify = function jwtVerifyFunc(req, token, metadata, opti
       return self._verify(verifiedToken, done);
     }
   });
-}
+};
 
 /*
  * We let the metadata loading happen in `authenticate` function, and use waterfall


### PR DESCRIPTION
Fixes Issue #254 - passReqToCallback does not work with bearer strategy

When 'passReqToCallback' is set to true, the callback passed in to a new strategy should get called with the three param option (req, user, done).  It does not.  Instead the two param option is always called (user, done).

In the bearerstrategy jwtVerify function, self.passReqToCallback was being used instead of self._options.passReqToCallback.  This cause the callback passed in to a new strategy to get called with the two param option even when "passReqToCallback" is set to true.