### PR TITLE
Issue #256 Support 'tfp' for B2C

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,12 @@ following:
 
   * Application claims: 'Display Name', Email Addresses', 'Given Name', 'Identity Provider', 'Surname', 'Users Object ID'
 
+* 'B2C_1_signin_acr': 
+
+  * Application claims: 'Display Name', Email Addresses', 'Given Name', 'Identity Provider', 'Surname', 'Users Object ID'
+
+  * After creating this policy, go the blade of this policy, click 'Edit' and then 'Token, session & SSO config'. Now switch the 'Claim representing policy ID' from 'tfp' to 'acr' and save the change.
+
 * 'B2C_1_resetpassword': 
 
   * Application claims: 'Email Addresses', 'Given Name', 'Users Object ID'

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -841,11 +841,17 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
 
     // For B2C, check the policy
     if (self._options.isB2C) {
-      if (!jwtClaims.acr || !CONSTANTS.POLICY_REGEX.test(jwtClaims.acr))
+      var policy_in_idToken;
+
+      if (jwtClaims.acr && CONSTANTS.POLICY_REGEX.test(jwtClaims.acr))
+        policy_in_idToken = jwtClaims.acr;
+      else if (jwtClaims.tfp && CONSTANTS.POLICY_REGEX.test(jwtClaims.tfp))
+        policy_in_idToken = jwtClaims.tfp.toLowerCase();
+      else
         return next(new Error('In _validateResponse: invalid B2C policy in id_token'));
 
-      if (params.policy !== jwtClaims.acr)
-        return next(new Error("In _validateResponse: acr in id_token does not match the policy used"));
+      if (params.policy !== policy_in_idToken)
+        return next(new Error("In _validateResponse: policy in id_token does not match the policy used"));
     }
 
     // check nonce

--- a/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
@@ -196,7 +196,7 @@ describe('OIDCStrategy hybrid flow test', function() {
     before(setReqFromAuthRespRedirect(id_token_in_auth_resp, code, nonce, 'wrong_policy'));
 
     it('should fail with invalid policy', function() {
-      chai.expect(challenge).to.equal('In _validateResponse: acr in id_token does not match the policy used');
+      chai.expect(challenge).to.equal('In _validateResponse: policy in id_token does not match the policy used');
     });
   });
 
@@ -311,7 +311,7 @@ describe('OIDCStrategy authorization code flow test', function() {
     before(setReqFromAuthRespRedirect(null, code, nonce, 'wrong_policy'));
 
     it('should fail with invalid policy', function() {
-      chai.expect(challenge).to.equal('In _validateResponse: acr in id_token does not match the policy used');
+      chai.expect(challenge).to.equal('In _validateResponse: policy in id_token does not match the policy used');
     });
   });
 

--- a/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
@@ -184,7 +184,7 @@ describe('B2C OIDCStrategy implicit flow test', function() {
     before(testPrepare(id_token, nonce, 'wrong policy'));
 
     it('should fail', function() {
-      chai.expect(challenge).to.equal('In _validateResponse: acr in id_token does not match the policy used');
+      chai.expect(challenge).to.equal('In _validateResponse: policy in id_token does not match the policy used');
     });
   });
 });

--- a/test/End_to_end_test/oidc_b2c_test.js
+++ b/test/End_to_end_test/oidc_b2c_test.js
@@ -234,6 +234,9 @@ var checkResult = (test_app_config, done) => {
     resultPageValidation(test_app_config, driver);
   })
   .then(() => {
+    driver.get('http://localhost:3000/login?p=b2c_1_signin_acr');
+  })
+  .then(() => {
     driver.get('http://localhost:3000/login?p=b2c_1_resetpassword');
     driver.wait(until.titleIs('User Details'), 10000);
   })


### PR DESCRIPTION
When we create a B2C policy, the policy is used to be stored in 'acr' claim in id_token. Now this is configurable, and policy is stored in 'tfp' instead by default.