### PR TITLE
Issue #172 ResponseMode should be optional in OIDC requests

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -425,6 +425,13 @@ function Strategy(options, verify) {
   if (options.responseType === 'id_token code')
     options.responseType = 'code id_token';
 
+  // For authorization code flow, the default response_mode is 'query'. If response_mode is
+  // not provided, we set it to 'query'.
+  // For hybrid and implicit flow, the default response_mode is 'fragment'. However, we do
+  // not support 'fragment', so user has to provide the response_mode.
+  if (!options.responseMode && options.responseType === 'code')
+    options.responseMode = 'query';
+
   var itemsToValidate = {};
   aadutils.copyObjectFields(options, itemsToValidate, ['clientID', 'redirectUrl', 'responseType', 'responseMode', 'identityMetadata']); 
 
@@ -1163,9 +1170,15 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
   const params = {
     'redirect_uri': oauthConfig.redirectUrl,
     'response_type': oauthConfig.responseType,
-    'response_mode': oauthConfig.responseMode,
     'client_id': oauthConfig.clientID
   };
+
+  // Don't send the response_mode if it is the default.
+  // Default response_mode for authorization code flow is 'query'.
+  // Default response_mode for hybrid/implicit flow is 'fragment'. We don't support 'fragment', so we
+  // always send the response_mode.
+  if (!(oauthConfig.responseType === 'code' && oauthConfig.responseMode === 'query'))
+    params['response_mode'] = oauthConfig.responseMode;
 
   log.info('We are sending the response_type: ', params.response_type);
   log.info('We are sending the response_mode: ', params.response_mode);


### PR DESCRIPTION
The default responseMode for 'code' flow is 'query', for hybrid/implicit is 'fragment'. Since we don't support 'fragment', we only need to not send 'query' response_mode in case of 'code' flow.