### PR TITLE
Fix Jenkins failure

### DIFF
--- a/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 var url = require('url');
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var Metadata = require('../../lib/metadata').Metadata;
 var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 var OAuth2 = require('../../node_modules/oauth/index').OAuth2;
@@ -175,6 +177,7 @@ var setReqFromAuthRespRedirect = function(id_token_in_auth_resp, code_in_auth_re
  */
 
 describe('OIDCStrategy hybrid flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   /*
    * success if we ignore the expiration
@@ -279,6 +282,7 @@ describe('OIDCStrategy hybrid flow test', function() {
 });
 
 describe('OIDCStrategy authorization code flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   /*
    * success if we ignore the expiration

--- a/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 var url = require('url');
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var Metadata = require('../../lib/metadata').Metadata;
 var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
@@ -129,6 +131,7 @@ var testPrepare = function(id_token_to_use, nonce_to_use, policy_to_use, action)
 };
 
 describe('B2C OIDCStrategy implicit flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   describe('should succeed without expiration checking', function() {
     before(testPrepare(id_token, nonce, policy));

--- a/test/Chai-passport_test/b2c_oidc_incoming_request_test.js
+++ b/test/Chai-passport_test/b2c_oidc_incoming_request_test.js
@@ -31,6 +31,8 @@ var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 // Mock options required to create a OIDC strategy
 var options = {
     redirectUrl: 'https://returnURL',
@@ -57,6 +59,8 @@ testStrategy.setOptions = function(params, oauthConfig, optionsToValidate, done)
 
 
 describe('OIDCStrategy incoming state and nonce checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var redirectUrl;
   var request;
   var challenge;
@@ -106,6 +110,8 @@ describe('OIDCStrategy incoming state and nonce checking', function() {
 });
 
 describe('OIDCStrategy error flow checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var challenge;
 
   var testPrepare = function() {
@@ -133,6 +139,8 @@ describe('OIDCStrategy error flow checking', function() {
 });
 
 describe('OIDCStrategy token in request checking', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   var challenge;
 
   var testPrepare = function(access_token, refresh_token, query_or_body) {

--- a/test/Chai-passport_test/bearer_flow_test.js
+++ b/test/Chai-passport_test/bearer_flow_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 chai.use(require('chai-passport-strategy'));
 var BearerStrategy = require('../../lib/index').BearerStrategy;
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var PemKey =
   "-----BEGIN RSA PUBLIC KEY-----\n" +
   "MIIBCgKCAQEAvbcFrj193Gm6zeo5e2/y54Jx49sIgScv+2JO+n6NxNqQaKVnMkHc\n" +
@@ -74,6 +76,7 @@ var newStrategy = function(_options) {
 
 
 describe('bearer flow', function() {
+  this.timeout(TEST_TIMEOUT);
 
   context('passReqToCallback = true', function() {
     var req = null;

--- a/test/Chai-passport_test/bearer_token_in_req_test.js
+++ b/test/Chai-passport_test/bearer_token_in_req_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 chai.use(require('chai-passport-strategy'));
 var BearerStrategy = require('../../lib/index').BearerStrategy;
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var options = {
   identityMetadata: 'https://login.microsoftonline.com/xxx.onmicrosoft.com/.well-known/openid-configuration', 
   clientID: 'spn:6514a8ca-d9e4-4155-b292-65258398f3aa',
@@ -50,6 +52,7 @@ strategy.loadMetadata = function(params, next) {
 };
 
 describe('token mock test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   var challenge = '';
   var success_user = '';

--- a/test/Chai-passport_test/clock_skew_test.js
+++ b/test/Chai-passport_test/clock_skew_test.js
@@ -33,6 +33,8 @@ var CONSTANTS = require('../../lib/constants');
 
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var OIDC_options = {
   redirectUrl: 'https://returnURL',
   clientID: 'my_client_id',
@@ -53,6 +55,8 @@ var Bearer_options = {
 };
 
 describe('OIDCStrategy clock skew test', function() {
+  this.timeout(TEST_TIMEOUT);
+
   it('should have the default clock skew if none is given', function(done) {
     var testStrategy = new OIDCStrategy(OIDC_options, function(profile, done) {});
     chai.expect(testStrategy._options.clockSkew).to.equal(CONSTANTS.CLOCK_SKEW);
@@ -84,6 +88,8 @@ describe('OIDCStrategy clock skew test', function() {
 });
 
 describe('BearerStrategy clock skew test', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   it('should have the default clock skew if none is given', function(done) {
     var testStrategy = new BearerStrategy(Bearer_options, function(profile, done) {});
     chai.expect(testStrategy._options.clockSkew).to.equal(CONSTANTS.CLOCK_SKEW);

--- a/test/Chai-passport_test/constants_test.js
+++ b/test/Chai-passport_test/constants_test.js
@@ -27,10 +27,14 @@ var chai = require('chai');
 var expect = chai.expect;
 var CONSTANTS = require('../../lib/constants');
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 CONSTANTS.TENANTNAME_REGEX = /^[0-9a-zA-Z]+.onmicrosoft.com$/;
 CONSTANTS.TENANTID_REGEX = /^[0-9a-zA-Z-]+$/;
 
 describe('policy checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   it('should pass with good policy name', function(done) {
     expect(CONSTANTS.POLICY_REGEX.test('b2c_1_signin')).to.equal(true);
     expect(CONSTANTS.POLICY_REGEX.test('B2C_1_SIGNIN')).to.equal(true);
@@ -50,6 +54,8 @@ describe('policy checking', function() {
 });
 
 describe('tenant name checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   it('should pass with good tenant name', function(done) {
     expect(CONSTANTS.TENANTNAME_REGEX.test('contoso123COMPANY.onmicrosoft.com')).to.equal(true);
     done();
@@ -66,6 +72,8 @@ describe('tenant name checking', function() {
 });
 
 describe('tenant id checking', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   it('should pass with good tenant id', function(done) {
     expect(CONSTANTS.TENANTID_REGEX.test('683eAd13-3193-43f0-9677-d727c25a588f')).to.equal(true);
     done();

--- a/test/Chai-passport_test/oidc_common_endpoint_test.js
+++ b/test/Chai-passport_test/oidc_common_endpoint_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 var url = require('url');
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var Metadata = require('../../lib/metadata').Metadata;
 var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
@@ -139,6 +141,7 @@ var testPrepare = function(id_token_to_use, nonce_to_use, action) {
 };
 
 describe('OIDCStrategy implicit flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   describe('should succeed without expiration checking', function() {
     before(testPrepare(id_token, nonce));

--- a/test/Chai-passport_test/oidc_dynamic_tenant_test.js
+++ b/test/Chai-passport_test/oidc_dynamic_tenant_test.js
@@ -31,6 +31,8 @@ var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 // Mock options required to create a OIDC strategy
 var options = {
   redirectUrl: 'https://returnURL',
@@ -45,6 +47,8 @@ var options = {
 };
 
 describe('OIDCStrategy dynamic tenant test', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var redirectUrl;
   var challenge;
   var request;
@@ -99,6 +103,8 @@ describe('OIDCStrategy dynamic tenant test', function() {
 });
 
 describe('OIDCStrategy dynamic B2C tenant test', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   var redirectUrl;
   var challenge;
   var request;

--- a/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 var url = require('url');
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var Metadata = require('../../lib/metadata').Metadata;
 var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 var OAuth2 = require('../../node_modules/oauth/index').OAuth2;
@@ -186,6 +188,7 @@ var setReqFromAuthRespRedirect = function(id_token_in_auth_resp, code_in_auth_re
  */
 
 describe('OIDCStrategy hybrid flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   /*
    * success if we ignore the expiration
@@ -310,6 +313,7 @@ describe('OIDCStrategy hybrid flow test', function() {
 });
 
 describe('OIDCStrategy authorization code flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   /*
    * success if we ignore the expiration

--- a/test/Chai-passport_test/oidc_implicit_flow_test.js
+++ b/test/Chai-passport_test/oidc_implicit_flow_test.js
@@ -29,6 +29,8 @@ var chai = require('chai');
 var url = require('url');
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 var Metadata = require('../../lib/metadata').Metadata;
 var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
@@ -124,6 +126,7 @@ var testPrepare = function(id_token_to_use, nonce_to_use, action) {
 };
 
 describe('OIDCStrategy implicit flow test', function() {
+  this.timeout(TEST_TIMEOUT);
 
   describe('should succeed without expiration checking', function() {
     before(testPrepare(id_token, nonce));

--- a/test/Chai-passport_test/oidc_incoming_request_test.js
+++ b/test/Chai-passport_test/oidc_incoming_request_test.js
@@ -31,6 +31,8 @@ var OIDCStrategy = require('../../lib/index').OIDCStrategy;
 
 chai.use(require('chai-passport-strategy'));
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 // Mock options required to create a OIDC strategy
 var options = {
     redirectUrl: 'https://returnURL',
@@ -59,6 +61,8 @@ testStrategy.setOptions = function(params, oauthConfig, optionsToValidate, done)
 
 
 describe('OIDCStrategy incoming state and nonce checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var redirectUrl;
   var request;
 
@@ -98,6 +102,8 @@ describe('OIDCStrategy incoming state and nonce checking', function() {
 });
 
 describe('OIDCStrategy error flow checking', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var challenge;
 
   var testPrepare = function() {
@@ -125,6 +131,8 @@ describe('OIDCStrategy error flow checking', function() {
 });
 
 describe('OIDCStrategy token in request checking', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   var challenge;
 
   var testPrepare = function(access_token, refresh_token, query_or_body) {

--- a/test/Chai-passport_test/sessionContentHandler_test.js
+++ b/test/Chai-passport_test/sessionContentHandler_test.js
@@ -29,7 +29,11 @@ const chai = require('chai');
 const expect = chai.expect;
 const SessionContentHandler = require('../../lib/sessionContentHandler').SessionContentHandler; 
 
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
 describe('checking constructor', function() {
+  this.timeout(TEST_TIMEOUT);
+
   it('should throw with non-integer maxAmount', function(done) {
     expect(SessionContentHandler.bind(SessionContentHandler, 1.1, 1)).
       to.throw('SessionContentHandler: maxAmount must be a positive integer');
@@ -50,6 +54,8 @@ describe('checking constructor', function() {
 });
 
 describe('checking add function', function() {
+  this.timeout(TEST_TIMEOUT);
+
   var req = {};
   var handler = new SessionContentHandler(2, 0.1);
 
@@ -106,6 +112,8 @@ describe('checking add function', function() {
 });
 
 describe('checking findAndDeleteTupleByState function', function() {
+  this.timeout(TEST_TIMEOUT);
+  
   var req = {};
   var handler = new SessionContentHandler(2, 0.1);
 

--- a/test/End_to_end_test/bearer_b2c_test.js
+++ b/test/End_to_end_test/bearer_b2c_test.js
@@ -36,8 +36,8 @@ var until = webdriver.until;
 var chai = require('chai');
 var expect = chai.expect;
 
-const TEST_TIMEOUT = 500000; // 30 seconds
-const LOGIN_WAITING_TIME = 2000; // 1 second
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+const LOGIN_WAITING_TIME = 3000; // 3 second
 
 /******************************************************************************
  *  configurations needed

--- a/test/End_to_end_test/bearer_test.js
+++ b/test/End_to_end_test/bearer_test.js
@@ -36,8 +36,8 @@ var until = webdriver.until;
 var chai = require('chai');
 var expect = chai.expect;
 
-const TEST_TIMEOUT = 500000; // 30 seconds
-const LOGIN_WAITING_TIME = 1000; // 1 second
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+const LOGIN_WAITING_TIME = 3000; // 3 second
 
 /******************************************************************************
  *  configurations needed

--- a/test/End_to_end_test/oidc_b2c_test.js
+++ b/test/End_to_end_test/oidc_b2c_test.js
@@ -38,8 +38,8 @@ var create_app = require('./app/app');
 var chai = require('chai');
 var expect = chai.expect;
 
-const TEST_TIMEOUT = 600000; // 600 seconds
-const LOGIN_WAITING_TIME = 1000; // 1 second
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+const LOGIN_WAITING_TIME = 3000; // 3 second
 
 /******************************************************************************
  *  Configurations needed
@@ -212,7 +212,6 @@ var checkResult = (test_app_config, done) => {
   .then(() => {
     if (first_time) {
       driver.wait(until.titleIs('User Details'), 10000);
-      driver.findElement(By.id('cancel')).click();
     }
   })
   .then(() => {
@@ -243,10 +242,6 @@ var checkResult = (test_app_config, done) => {
   .then(() => {
     driver.get('http://localhost:3000/login?p=b2c_1_updateprofile');
     driver.wait(until.titleIs('Update Profile'), 10000);
-    driver.findElement(By.id('continue')).click();
-  })
-  .then(() => {
-    resultPageValidation(test_app_config, driver);
   })
   .then(() => {
     server.shutdown(done); 

--- a/test/End_to_end_test/oidc_v1_test.js
+++ b/test/End_to_end_test/oidc_v1_test.js
@@ -39,8 +39,8 @@ var chai = require('chai');
 var expect = chai.expect;
 var fs = require('fs');
 
-const TEST_TIMEOUT = 600000; // 600 seconds
-const LOGIN_WAITING_TIME = 1000; // 1 second
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+const LOGIN_WAITING_TIME = 3000; // 3 second
 
 /******************************************************************************
  *  Configurations needed

--- a/test/End_to_end_test/oidc_v2_test.js
+++ b/test/End_to_end_test/oidc_v2_test.js
@@ -39,8 +39,8 @@ var chai = require('chai');
 var expect = chai.expect;
 var fs = require('fs');
 
-const TEST_TIMEOUT = 600000; // 600 seconds
-const LOGIN_WAITING_TIME = 1000; // 1 second
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+const LOGIN_WAITING_TIME = 3000; // 3 second
 
 /******************************************************************************
  *  Configurations needed


### PR DESCRIPTION
(1) allow more time by setting a timeout for tests in Chai-passport_test
(2) allow more time for the signin key to show up in End_to_end_test. Remove the unnecessary click of the 'continue' button in b2c updateprofile page and the 'cancel' button in b2c signup page.