### PR TITLE
Issue #285 express-session free support

### DIFF
--- a/lib/cookieContentHandler.js
+++ b/lib/cookieContentHandler.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use restrict';
+
+var crypto = require('crypto');
+var createBuffer = require('./jwe').createBuffer;
+
+/*
+ * the handler for state/nonce/policy
+ * @maxAmount          - the max amount of {state: x, nonce: x, policy: x} tuples you want to save in cookie
+ * @maxAge            - when a tuple in session expires in seconds
+ * @cookieEncryptionKeys  
+ *                    - keys used to encrypt and decrypt cookie
+ */ 
+function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys) {
+  if (!maxAge || (typeof maxAge !== 'number' || maxAge <= 0))
+    throw new Error('CookieContentHandler: maxAge must be a positive number');
+  this.maxAge = maxAge;  // seconds
+
+  if (!maxAmount || (typeof maxAmount !== 'number' || maxAmount <= 0 || maxAmount % 1 !== 0))
+    throw new Error('CookieContentHandler: maxAmount must be a positive integer');
+  this.maxAmount = maxAmount;
+
+  if (!cookieEncryptionKeys || !Array.isArray(cookieEncryptionKeys) || cookieEncryptionKeys.length === 0)
+    throw new Error('CookieContentHandler: cookieEncryptionKeys must be a non-emptry array');
+
+  for (var i = 0; i < cookieEncryptionKeys.length; i++) {
+    var item = cookieEncryptionKeys[i];
+    if (!item.key || !item.iv)
+      throw new Error(`CookieContentHandler: array item ${i+1} in cookieEncryptionKeys must have the form { key: , iv: }`);
+    if (item.key.length !== 32)
+      throw new Error(`CookieContentHandler: key number ${i+1} is ${item.key.length} bytes, expected: 32 bytes`);
+    if (item.iv.length !== 12)
+      throw new Error(`CookieContentHandler: iv number ${i+1} is ${item.iv.length} bytes, expected: 12 bytes`);
+  }
+
+  this.cookieEncryptionKeys = cookieEncryptionKeys;
+}
+
+CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, stateToFind) {
+  if (!req.cookies)
+    throw new Error('Cookie is not found in request. Did you forget to use cookie parsing middleware such as cookie-parser?');
+  
+  var cookieEncryptionKeys = this.cookieEncryptionKeys;
+
+  var tuple = null;
+
+  // try every key and every cookie
+  for (var i = 0; i < cookieEncryptionKeys.length; i++) {
+    var item = cookieEncryptionKeys[i];
+    var key = createBuffer(item.key);
+    var iv = createBuffer(item.iv);
+
+    for (var cookie in req.cookies) {     
+      if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.')) {
+        var encrypted = cookie.substring(13);
+
+        try {
+          var decrypted = decryptCookie(encrypted, key, iv);
+          tuple = JSON.parse(decrypted);
+        } catch (ex) {
+          continue;
+        }
+
+        if (tuple.state === stateToFind) {
+          res.clearCookie(cookie);
+          return tuple;      
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
+  var cookies = [];
+
+  // collect the related cookies
+  for (var cookie in req.cookies) {     
+    if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.'))
+      cookies.push(cookie);
+  }
+
+  // only keep the most recent maxAmount-1 many cookies
+  if (cookies.length > this.maxAmount - 1) {
+    cookies.sort();
+
+    var numberToRemove = cookies.length - (this.maxAmount - 1);
+
+    for (var i = 0; i < numberToRemove; i++) {
+      res.clearCookie(cookies[0]);
+      cookies.shift();
+    }
+  }
+
+  // add the new cookie
+
+  var tupleString = JSON.stringify(tupleToAdd);
+
+  var item = this.cookieEncryptionKeys[0];
+  var key = createBuffer(item.key);
+  var iv = createBuffer(item.iv);
+
+  var encrypted = encryptCookie(tupleString, key, iv);
+
+  res.cookie('passport-aad.' + Date.now() + '.' + encrypted, 0, { maxAge: this.maxAge * 1000, httpOnly: true });
+};
+
+var encryptCookie = function(content, key, iv) {
+  var cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+
+  var encrypted = cipher.update(content, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  var authTag = cipher.getAuthTag().toString('hex');
+
+  return encrypted + '.' + authTag;
+};
+
+var decryptCookie = function(encrypted, key, iv) {
+  var parts = encrypted.split('.');
+  if (parts.length !== 3)
+    throw new Error('invalid cookie');
+
+  // the first part is timestamp, ignore it
+  var content = createBuffer(parts[1], 'hex');
+  var authTag = createBuffer(parts[2], 'hex');
+
+  var decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  var decrypted = decipher.update(content, 'hex', 'utf8');
+  decrypted +=  decipher.final('utf8');
+
+  return decrypted;
+};
+
+exports.CookieContentHandler = CookieContentHandler;
+

--- a/lib/jwe.js
+++ b/lib/jwe.js
@@ -522,4 +522,7 @@ exports.decrypt = (jweString, jweKeyStore, log, callback) => {
   return callback(content_result.error, content_result.content);
 };
 
+exports.createBuffer = createBuffer;
+
+
 

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -50,6 +50,7 @@ const Log = require('./logging').getLogger;
 const Metadata = require('./metadata').Metadata;
 const OAuth2 = require('oauth').OAuth2;
 const SessionContentHandler = require('./sessionContentHandler').SessionContentHandler;
+const CookieContentHandler = require('./cookieContentHandler').CookieContentHandler;
 const Validator = require('./validator').Validator;
 
 // global variable definitions
@@ -234,6 +235,20 @@ function onProfileLoaded(strategy, args) {
  *                          Set `passReqToCallback` to true use the `function(req, token, done)` signature for the verify function
  *                          Set `passReqToCallback` to false use the `function(token, done)` signature for the verify function 
  *
+ *   - `useCookieInsteadOfSession`
+ *                          (1) Required to set true if you don't want to use session. Default value is false.
+ *                          (2) Description:
+ *                          Passport-azure-ad needs to save state and nonce somewhere for validation purpose. If this option is set true, it will encrypt 
+ *                          state and nonce and put them into cookie. If this option is false, we save state and nonce in session.
+ *
+ *   - `cookieEncryptionKeys`
+ *                          (1) Required if `useCookieInsteadOfSession` is true.
+ *                          (2) Description:
+ *                          This must be an array of key items. Each key item has the form { key: '...', iv: '...' }, where key is any string of length 32,
+ *                          and iv is any string of length 12. 
+ *                          We always use the first key item with AES-256-GCM algorithm to encrypt cookie, but we will try every key item when we decrypt
+ *                          cookie. This helps when you want to do key roll over.
+ *
  *   - `scope`              (1) Optional
  *                          (2) must be a string or an array of strings
  *                          (3) Description:
@@ -250,7 +265,12 @@ function onProfileLoaded(strategy, args) {
  *   - `nonceLifetime`      (1) Optional
  *                          (2) must be a positive integer
  *                          (3) Description:
- *                          the lifetime of nonce in session, default value is NONCE_LIFE_TIME
+ *                          the lifetime of nonce in session or cookie, default value is NONCE_LIFE_TIME
+ *
+ *   - `nonceMaxAmount`     (1) Optional
+ *                          (2) must be a positive integer
+ *                          (3) Description:
+ *                          the max amount of nonce in session or cookie, default value is NONCE_MAX_AMOUNT
  *
  *   - `clockSkew`          (1) Optional
  *                          (2) must be a positive integer
@@ -276,6 +296,8 @@ function onProfileLoaded(strategy, args) {
  *     passReqToCallback: config.creds.passReqToCallback,
  *     loggingLevel: config.creds.loggingLevel,
  *     nonceLifetime: config.creds.nonceLifetime,
+ *     useCookieInsteadOfSession: config.creds.useCookieInsteadOfSession,
+ *     cookieEncryptionKeys: config.creds.cookieEncryptionKeys
  *   },
  *   function(token, done) {
  *     User.findById(token.sub, function (err, user) {
@@ -310,11 +332,20 @@ function Strategy(options, verify) {
   this._verify = verify;
   this._passReqToCallback = !!options.passReqToCallback;
 
-  // For each microsoft login page tab, we generate a {state, nonce, policy, timeStamp} tuple,
-  // normally user won't keep opening microsoft login page in new tabs without putting their 
-  // password for more than 10 tabs, so we only keep the most recent 10 tuples in session.
-  // The lifetime of each tuple is 60 minutes or user specified.
-  this._sessionContentHandler = new SessionContentHandler(NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME);
+  if (options.useCookieInsteadOfSession === true)
+    this._useCookieInsteadOfSession = true;
+  else
+    this._useCookieInsteadOfSession = false;
+
+  if (!this._useCookieInsteadOfSession) {
+    // For each microsoft login page tab, we generate a {state, nonce, policy, timeStamp} tuple,
+    // normally user won't keep opening microsoft login page in new tabs without putting their 
+    // password for more than 10 tabs, so we only keep the most recent 10 tuples in session.
+    // The lifetime of each tuple is 60 minutes or user specified.
+    this._sessionContentHandler = new SessionContentHandler(options.nonceMaxAmount || NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME);
+  } else {
+    this._cookieContentHandler = new CookieContentHandler(options.nonceMaxAmount || NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME, options.cookieEncryptionKeys);
+  }
 
   /* When a user is authenticated for the first time, passport adds a new field
    * to req.session called 'passport', and puts a 'user' property inside (or your
@@ -542,6 +573,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   var prompt = options && options.prompt;
   var extraAuthReqQueryParams = options && options.extraAuthReqQueryParams;
   var extraTokenReqQueryParams = options && options.extraTokenReqQueryParams;
+  var response = options && options.response;
 
   // validate tenantIdOrName if it is provided
   if (tenantIdOrName && !CONSTANTS.TENANTNAME_REGEX.test(tenantIdOrName) && !CONSTANTS.TENANTID_REGEX.test(tenantIdOrName))
@@ -550,7 +582,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
   var params = { 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams }; 
   // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
-  var oauthConfig = { 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt };
+  var oauthConfig = { 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt, 'response': response };
   // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc  
   var optionsToValidate = {}; 
 
@@ -560,7 +592,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
        * Step 1. Collect information from the req and save the info into params
        ****************************************************************************/
       (next) => {
-        return self.collectInfoFromReq(params, req, next);
+        return self.collectInfoFromReq(params, req, next, response);
       },
 
       /*****************************************************************************
@@ -619,7 +651,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
  * @param {Object} req    
  * @param {Object} next
  */
-Strategy.prototype.collectInfoFromReq = function(params, req, next) {
+Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
   const self = this;
 
   // the things we will put into 'params':
@@ -667,12 +699,21 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next) {
   if (params.id_token || params.code || params.err) {
     if (!params.state)
       return next(new Error('In collectInfoFromReq: missing state in the request'));
-    var tuple = self._sessionContentHandler.findAndDeleteTupleByState(req, self._key, params.state);
+
+    var tuple;
+
+    if (!self._useCookieInsteadOfSession)
+      tuple = self._sessionContentHandler.findAndDeleteTupleByState(req, self._key, params.state);
+    else
+      tuple = self._cookieContentHandler.findAndDeleteTupleByState(req, response, params.state);
+
     if (!tuple)
       return next(new Error('In collectInfoFromReq: invalid state received in the request'));
+
     params.nonce = tuple['nonce'];
     params.policy = tuple['policy'];
     params.resource = tuple['resource'];
+
     // user provided tenantIdOrName will be ignored for redirectUrl, since we saved the one we used in session
     if (params.tenantIdOrName)
       log.info(`user provided tenantIdOrName '${params.tenantIdOrName}' is ignored for redirectUrl, we will use the one stored in session`);
@@ -1251,14 +1292,31 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
     if (!policy || !CONSTANTS.POLICY_REGEX.test(policy))
       return next(new Error(`In _flowInitializationHandler: the given policy ${policy} given in the request is invalid`));
   }
-  // add state/nonce/policy/timeStamp tuple to session
+
+  // add state/nonce/policy/timeStamp tuple to session or cookie
   let state = params.state = oauthConfig.customState ? ('CUSTOM' + aadutils.uid(32) + oauthConfig.customState) : aadutils.uid(32);
   let nonce = params.nonce = aadutils.uid(32);
   let resource = oauthConfig.resource ? oauthConfig.resource : null;
   if (resource)
     params.resource = resource;
-  self._sessionContentHandler.add(req, self._key, {state: state, nonce: nonce, policy: policy, resource: resource, tenantIdOrName: oauthConfig.tenantIdOrName, timeStamp: Date.now()});
 
+  var tuple = { state: state, nonce: nonce };
+  if (policy)
+    tuple.policy = policy;
+  if (resource)
+    tuple.resource = resource;
+  if (oauthConfig.tenantIdOrName)
+    tuple.tenantIdOrName = oauthConfig.tenantIdOrName;
+
+  if (!self._useCookieInsteadOfSession) {
+    tuple.timeStamp = Date.now();
+    self._sessionContentHandler.add(req, self._key, tuple);
+  } else {
+    // we don't need to record timestamp if we use cookie, since we can set the
+    // expiration when we set cookie
+    self._cookieContentHandler.add(req, oauthConfig.response, tuple);
+  }
+  
   // add scope
   params.scope = oauthConfig.scope;
 

--- a/test/Chai-passport_test/cookie_test.js
+++ b/test/Chai-passport_test/cookie_test.js
@@ -53,6 +53,15 @@ var countCookie = function() {
   return number;
 };
 
+var getFirstPassportCookie = function() {
+  for (var cookie in req.cookies) {
+    if (req.cookies.hasOwnProperty(cookie) & cookie.startsWith('passport-aad.'))
+      return cookie;
+  }
+
+  return null;
+};
+
 describe('cookie test', function() {
   this.timeout(TEST_TIMEOUT);
 
@@ -66,6 +75,11 @@ describe('cookie test', function() {
     // set the first cookie
     handler.add(req, res, { state: '1', nonce: 'some nonce' });
     expect(countCookie()).to.equal(1);
+
+    // check the cookie is encrypted
+    var cookie = getFirstPassportCookie();
+    // skip the passport-aad prefix and timestamp, check the encrypted content and authTag
+    expect(cookie.substring(27)).equal('6ba133e675492c0c4fef3d2fb4bb2166fb246d29ed9f03372e7e647119de7676766e.f79b7a90af7173b807da797994f46be7');
 
     // set the second cookie
     handler.add(req, res, { state: '2', nonce: 'some nonce' });

--- a/test/Chai-passport_test/cookie_test.js
+++ b/test/Chai-passport_test/cookie_test.js
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the 'Software'), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+var CookieContentHandler = require('../../lib/cookieContentHandler').CookieContentHandler;
+
+const TEST_TIMEOUT = 1000000; // 1000 seconds
+
+var req = {};
+var res = {};
+
+res.cookie = function(cookieProperty, value) {
+  if (!req.cookies)
+    req.cookies = {};
+  req.cookies[cookieProperty] = value;
+};
+
+res.clearCookie = function(cookieProperty) {
+  delete req.cookies[cookieProperty];
+};
+
+var countCookie = function() {
+  var number = 0;
+
+  for (var cookie in req.cookies) {
+    if (req.cookies.hasOwnProperty(cookie) & cookie.startsWith('passport-aad.'))
+      number++;
+  }
+
+  return number;
+};
+
+describe('cookie test', function() {
+  this.timeout(TEST_TIMEOUT);
+
+  it('should pass adding and deleting cookies', function(done) {
+    // create a handler
+    var handler = new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY', iv: '60iP0h6vJoEa' }, { key: '12345678901234567890123456789012', iv: '123456789012' } ]);
+    
+    // clear request
+    req = {}; 
+
+    // set the first cookie
+    handler.add(req, res, { state: '1', nonce: 'some nonce' });
+    expect(countCookie()).to.equal(1);
+
+    // set the second cookie
+    handler.add(req, res, { state: '2', nonce: 'some nonce' });
+    expect(countCookie()).to.equal(2);
+
+    // set the third cookie, since we only allow two cookies, the first will be deleted
+    handler.add(req, res, { state: '3', nonce: 'some nonce' });
+    expect(countCookie()).to.equal(2);
+
+    // try to find the first cookie, should not be there
+    expect(handler.findAndDeleteTupleByState(req, res, '1')).to.equal(null);
+
+    // try to find the second cookie, should be there and deleted after the retrieval
+    expect(handler.findAndDeleteTupleByState(req, res, '2').state).to.equal('2');
+    expect(countCookie()).to.equal(1);
+
+    // try to find the third cookie, should be there and deleted after the retrieval
+    expect(handler.findAndDeleteTupleByState(req, res, '3').state).to.equal('3');
+    expect(countCookie()).to.equal(0);
+
+    done();
+  });
+
+  it('should fail if no valid keys', function(done) {
+    // create a handler
+    var handler1 = new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY', iv: '60iP0h6vJoEa' } ]);
+    var handler2 = new CookieContentHandler(2, 10, [ { key: '12345678901234567890123456789012', iv: '123456789012' } ]);
+
+    // clear request
+    req = {}; 
+
+    // set cookie using handler1
+    handler1.add(req, res, { state: '1', nonce: 'some nonce' });
+    expect(countCookie()).to.equal(1);
+
+    // try to find the cookie using handler2, this should not work, we should still have the cookie in request
+    expect(handler2.findAndDeleteTupleByState(req, res, '1')).to.equal(null);
+    expect(countCookie()).to.equal(1);
+
+    // try to find the cookie using handler1, this should work, we should have no cookie left in request
+    expect(handler1.findAndDeleteTupleByState(req, res, '1').state).to.equal('1');
+    expect(countCookie()).to.equal(0);
+
+    done();
+  });
+
+  it('should throw if the constructor parameters are inappropriate', function(done) {
+    var exception;
+
+    // 1. wrong key size (key size != 32)
+
+    try {
+      new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61', iv: '60iP0h6vJoEa' }, { key: '12345678901234567890123456789012', iv: '123456789012' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: key number 1 is 14 bytes, expected: 32 bytes');
+
+    // 2. wrong iv size (key size != 12)
+
+    try {
+      new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY', iv: '60iP0h6vJoEa' }, { key: '12345678901234567890123456789012', iv: '123' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: iv number 2 is 3 bytes, expected: 12 bytes');
+
+    // 3. wrong format ( not {key:, iv: } )
+
+    try {
+      new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY' }, { key: '12345678901234567890123456789012', iv: '123' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: array item 1 in cookieEncryptionKeys must have the form { key: , iv: }');
+
+    try {
+      new CookieContentHandler(2, 10, [ { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY', iv: '60iP0h6vJoEa' }, { iv: '123' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: array item 2 in cookieEncryptionKeys must have the form { key: , iv: }');
+
+    // 4. maxAmount, maxAge not positive number
+
+    try {
+      new CookieContentHandler(-1, 10, [ { key: '12345678901234567890123456789012', iv: '123456789012' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: maxAmount must be a positive integer');
+
+    try {
+      new CookieContentHandler(1, -1, [ { key: '12345678901234567890123456789012', iv: '123456789012' } ]);
+    } catch(ex) {
+      exception = ex;
+    }
+
+    expect(exception.message).to.equal('CookieContentHandler: maxAge must be a positive number');
+
+    done();
+  });
+});

--- a/test/End_to_end_test/app/app_for_cookie.js
+++ b/test/End_to_end_test/app/app_for_cookie.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the 'Software'), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use strict';
+
+var users = [];
+
+module.exports = function(strategyOptions) {
+  var base64url = require('base64url');
+  var express = require('express');
+  var cookieParser = require('cookie-parser');
+  var expressSession = require('express-session');
+  var bodyParser = require('body-parser');
+  var methodOverride = require('method-override');
+  var passport = require('passport');
+  var request = require('request');
+  var enableGracefulShutdown = require('server-graceful-shutdown');
+  var OIDCStrategy = require('../../../lib/index').OIDCStrategy;
+
+  users = [];
+
+  var findBySub = function(sub, fn) {
+    for (var i = 0, len = users.length; i < len; i++) {
+      var user = users[i];
+      if (user.sub === sub)
+        return fn(null, user);
+    }
+    return fn(null, null);
+  };
+
+  var strategy = new OIDCStrategy(strategyOptions, 
+    function(profile, done) {
+      findBySub(profile.sub, function(err, user) {
+        if (!user) {
+          users.push(profile);
+          return done(null, profile);
+        }
+        return done(null, user);
+      });
+    }
+  );
+
+  passport.use(strategy);
+  passport.serializeUser(function(user, done) { done(null, user.sub); });
+  passport.deserializeUser(function(sub, done) {
+    findBySub(sub, function (err, user) {
+      done(err, user);
+    });
+  });
+
+  var app = express();
+
+  app.set('views', __dirname + '/views');
+  app.set('view engine', 'ejs');
+  app.use(express.logger());
+  app.use(methodOverride());
+  app.use(cookieParser());
+  app.use(bodyParser.urlencoded({ extended : true }));
+  app.use(passport.initialize());
+  app.use(passport.session());
+  app.use(app.router);
+
+  app.get('/', function(req, res) {
+      res.render('index', { user: null });
+  });
+
+  app.get('/login', (req, res, next) => {
+    req.logout();
+
+    passport.authenticate('azuread-openidconnect', { response: res, failureRedirect: '/result' })(req, res, next);
+  }, (req, res) => {
+    res.render('apiResult', { result: 'succeeded' });
+  });
+
+  app.post('/auth/openid/return', (req, res, next) => {
+      passport.authenticate('azuread-openidconnect', { response: res, failureRedirect: '/result' })(req, res, next);
+    }, (req, res) => {
+      res.render('apiResult', { result: 'succeeded' });
+    }
+  );
+
+  app.get('/result', function(req, res) {
+    res.render('apiResult', { result: 'failed' });
+  });
+
+  var server = app.listen(3000);
+  enableGracefulShutdown(server);
+  return server;
+};
+
+

--- a/test/End_to_end_test/oidc_cookie_test.js
+++ b/test/End_to_end_test/oidc_cookie_test.js
@@ -37,7 +37,7 @@ var base64url = require('base64url');
 var chai = require('chai');
 var expect = chai.expect;
 
-const TEST_TIMEOUT = 500000; // 30 seconds
+const TEST_TIMEOUT = 500000; // 500 seconds
 const LOGIN_WAITING_TIME = 1000; // 1 second
 
 /******************************************************************************
@@ -112,7 +112,7 @@ describe('authorization code flow test', function() {
 describe('implicit flow test', function() {
   this.timeout(TEST_TIMEOUT);
 
-  it('start app for authorization code flow', function(done) {
+  it('start app for implicit flow', function(done) {
     if (!driver)
       driver = chromedriver.get_driver();
 
@@ -132,7 +132,7 @@ describe('implicit flow test', function() {
 describe('hybrid flow test', function() {
   this.timeout(TEST_TIMEOUT);
 
-  it('start app for authorization code flow', function(done) {
+  it('start app for hybrid flow', function(done) {
     if (!driver)
       driver = chromedriver.get_driver();
 

--- a/test/End_to_end_test/oidc_cookie_test.js
+++ b/test/End_to_end_test/oidc_cookie_test.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the 'Software'), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use strict';
+
+/******************************************************************************
+ *  Testing tools setup
+ *****************************************************************************/
+
+var chromedriver = require('./driver');
+var service = chromedriver.get_service();
+var webdriver = chromedriver.webdriver;
+var By = webdriver.By;
+var until = webdriver.until;
+var base64url = require('base64url');
+
+var chai = require('chai');
+var expect = chai.expect;
+
+const TEST_TIMEOUT = 500000; // 30 seconds
+const LOGIN_WAITING_TIME = 1000; // 1 second
+
+/******************************************************************************
+ *  configurations needed
+ *****************************************************************************/
+
+var driver;
+var server;
+
+var code_config = {
+  identityMetadata: 'https://testingsts.azurewebsites.net/.well-known/openid-configuration', 
+  //identityMetadata: 'http://localhost:8081/.well-known/openid-configuration',
+  clientID: 'client-001',
+  responseType: 'code', 
+  responseMode: 'form_post', 
+  redirectUrl: 'http://localhost:3000/auth/openid/return', 
+  allowHttpForRedirectUrl: true,
+  allowMultiAudiencesInToken: true,
+  clientSecret: 'secret-001', 
+  validateIssuer: true,
+  passReqToCallback: false,
+  scope: null,
+  loggingLevel: 'info',
+  useCookieInsteadOfSession: true,
+  nonceLifetime: null,
+  nonceMaxAmount: 5,  
+  cookieEncryptionKeys: [ 
+      { key: '3zTvzr3p67VC61jmV54rIYu1545x4TlY', iv: '60iP0h6vJoEa' }, 
+      { key: '12345678901234567890123456789012', iv: '123456789012' }]
+};
+
+var implicit_config = JSON.parse(JSON.stringify(code_config));
+implicit_config.responseType = 'id_token';
+
+var hybrid_config = JSON.parse(JSON.stringify(code_config));
+hybrid_config.responseType = 'code id_token';
+
+var runAuthTest = (done) => {
+  driver.get('http://localhost:3000/login').then(() => {
+    driver.wait(until.titleIs('result'), 10000);
+    driver.findElement(By.id('status')).getText().then((text) => { 
+      expect(text).to.equal('succeeded');
+      done();
+    });
+  });  
+};
+
+/******************************************************************************
+ *  The test cases
+ *****************************************************************************/
+
+describe('authorization code flow test', function() {
+  this.timeout(TEST_TIMEOUT);
+
+  it('start app for authorization code flow', function(done) {
+    if (!driver)
+      driver = chromedriver.get_driver();
+
+    server = require('./app/app_for_cookie')(code_config);
+    done();
+  });
+
+  it('should succeeded', function(done) {
+    runAuthTest(done);
+  });
+
+  it('shut down app', function(done) {
+    server.shutdown(done);
+  });
+});
+
+describe('implicit flow test', function() {
+  this.timeout(TEST_TIMEOUT);
+
+  it('start app for authorization code flow', function(done) {
+    if (!driver)
+      driver = chromedriver.get_driver();
+
+    server = require('./app/app_for_cookie')(implicit_config);
+    done();
+  });
+
+  it('should succeeded', function(done) {
+    runAuthTest(done);
+  });
+
+  it('shut down app', function(done) {
+    server.shutdown(done);
+  });
+});
+
+describe('hybrid flow test', function() {
+  this.timeout(TEST_TIMEOUT);
+
+  it('start app for authorization code flow', function(done) {
+    if (!driver)
+      driver = chromedriver.get_driver();
+
+    server = require('./app/app_for_cookie')(hybrid_config);
+    done();
+  });
+
+  it('should succeeded', function(done) {
+    runAuthTest(done);
+  });
+
+  it('shut down app', function(done) {
+    driver.quit();
+    service.stop();
+    server.shutdown(done);
+  });
+});
+
+


### PR DESCRIPTION
We used to save state and nonce in session, so session is always required. Now we can encrypt and decrypt
state and nonce, and put them into cookie, so session is no longer mandatory.

We provided two more options: useCookieInsteadOfSession, cookieEncryptionKeys. To use cookie, first set the first option to true.
For the second option, provide an array of { key: '...', iv: '...' } items. For each item, key is any string
of size 32, and iv is any string of size 12. We will use the first item (with AES-256-GCM algorithm) to encrypt cookie, but we try every
item to decrypt cookie, so you can easily do key rollover.