### PR TITLE
catch exception thrown for missing kid

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -951,12 +951,16 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
 
   // get Pem Key
   var PEMkey = null;
-  if (decoded.header.kid) {
-    PEMkey = params.metadata.generateOidcPEM(decoded.header.kid);
-  } else if (decoded.header.x5t) {
-    PEMkey = params.metadata.generateOidcPEM(decoded.header.x5t);
-  } else {
-    return next(new Error('In _validateResponse: We did not receive a token we know how to validate'));
+  try {
+    if (decoded.header.kid) {
+      PEMkey = params.metadata.generateOidcPEM(decoded.header.kid);
+    } else if (decoded.header.x5t) {
+      PEMkey = params.metadata.generateOidcPEM(decoded.header.x5t);
+    } else {
+      return next(new Error('In _validateResponse: We did not receive a token we know how to validate'));
+    }
+  } catch (error) {
+    return next(new Error('In _validateResponse: failed to generate PEM key due to: ' + error.message));
   }
   log.info('PEMkey generated: ' + PEMkey);
 


### PR DESCRIPTION
generateOidcPEM throws an error if kid is missing, so we have to use try catch here.