### PR TITLE
added support for advanced policy name which has prefix b2c_1a_

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,7 +27,7 @@
 
 var CONSTANTS = {};
 
-CONSTANTS.POLICY_REGEX = /^b2c_1_[0-9a-z._-]+$/i;    // policy is case insensitive
+CONSTANTS.POLICY_REGEX = /^b2c_1a?_[0-9a-z._-]+$/i;    // policy is case insensitive
 CONSTANTS.TENANTNAME_REGEX = /^[0-9a-zA-Z]+.onmicrosoft.com$/;
 CONSTANTS.TENANTID_REGEX = /^[0-9a-zA-Z-]+$/;
 

--- a/test/Chai-passport_test/constants_test.js
+++ b/test/Chai-passport_test/constants_test.js
@@ -41,6 +41,11 @@ describe('policy checking', function() {
     expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My.SIGNIN')).to.equal(true);
     expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My_SIGNIN')).to.equal(true);
     expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My-SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1a_signin')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1a_SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1a_My.SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1A_My_SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1A_My-SIGNIN')).to.equal(true);
     done();
   });
 
@@ -49,6 +54,10 @@ describe('policy checking', function() {
     expect(CONSTANTS.POLICY_REGEX.test('b2c_SIGNIN')).to.equal(false);
     expect(CONSTANTS.POLICY_REGEX.test('b2c_1_')).to.equal(false);
     expect(CONSTANTS.POLICY_REGEX.test('b2c_1_*SIGNIN')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('signin')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_a_SIGNIN')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1A_')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1A_*SIGNIN')).to.equal(false);
     done();
   });
 });


### PR DESCRIPTION
The current version of passport_azure_ad only allow policy names which start with "b2c_1_". However, it does not work with AAD B2C advanced policy name, which starts with "b2c_1a_". 

See more about the advanced policy at https://github.com/Azure-Samples/active-directory-b2c-advanced-policies/blob/master/Documentation/Features%20part%203.md#core-elements-of-the-b2c_1a_base-policy

Therefore this pull request is to update the regex validator of the policy name to support  "b2c_1a_". 

Unit testes were updated and executed.

