### PR TITLE
Fix: Cannot set cookie on the response.

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -578,7 +578,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   var prompt = options && options.prompt;
   var extraAuthReqQueryParams = options && options.extraAuthReqQueryParams;
   var extraTokenReqQueryParams = options && options.extraTokenReqQueryParams;
-  var response = options && options.response;
+  var response = options && options.response || req.res;
 
   // validate tenantIdOrName if it is provided
   if (tenantIdOrName && !CONSTANTS.TENANTNAME_REGEX.test(tenantIdOrName) && !CONSTANTS.TENANTID_REGEX.test(tenantIdOrName))


### PR DESCRIPTION
When trying to use this strategy, I ran into a lot of trouble using the cookies.

All of my calls resulted with the following error, crashing my server:
```
TypeError: Cannot read property 'cookie' of undefined
    CookieContentHandler.add (node_modules/passport-azure-ad/lib/cookieContentHandler.js:130:6)
    Strategy.flowInitializationHandler [as _flowInitializationHandler] (node_modules/passport-azure-ad/lib/oidcstrategy.js:1339:32)
    async.waterfall (node_modules/passport-azure-ad/lib/oidcstrategy.js:630:23)
    fn (node_modules/passport-azure-ad/node_modules/async/lib/async.js:746:34)
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:1213:16
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:166:37
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:706:43
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:167:37
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:1209:30
    node_modules/passport-azure-ad/node_modules/async/lib/async.js:52:16
    Immediate.<anonymous> (node_modules/passport-azure-ad/node_modules/async/lib/async.js:1206:34)
```

The config looks like this:
```
{
    provider        : 'oauth2',
    module          : 'passport-azure-ad',
    strategy        : 'OIDCStrategy',
    callbackPath    : '/auth/oauth2/callback',
    authPath        : '/auth/oauth2',
    authScheme      : 'openid connect',
    passReqToCallback: true,
    useCookieInsteadOfSession: true,  // use cookie, not session
    cookieEncryptionKeys: [
      { key: '0Gs2wLkKhhYYfusiaMTlAmktyA7FnSJX', iv: '60iP5h6vJoEa' },
    ], // encrypt/decrypt key and iv, see `cookieEncryptionKeys` instruction in section 5.1.1.2
    loggingLevel    : 'info',
    responseType    : 'code',
    responseMode    : 'query',
    redirectUrl     : 'https://' + 'test' + '.server.com/auth/oauth2/callback',
    identityMetadata: 'https://login.microsoftonline.com/3cb4fe21-****-****-****-0fb49fc18094/.well-known/openid-configuration',
    clientID        : 'c328cecc-****-****-****-6e9fb1c06307',
    clientSecret    : 'a3F1YMI4Ip**********tVbEWudgc4ur6LJuqhpwtL0=',
    scope           : ["email", "profile"],
}
```

The error happened because the response was not passed from passport into the `options` object.

Seeing that it was already attached to `req` in express 4, I added it to the `options` object.