### PR TITLE
B2C policy is a part of the path as opposed to query param

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -850,10 +850,10 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
         var policyChecker = (endpoint, policy) => {
           var u = {};          
           try {
-            u = url.parse(endpoint, true);
+            u = url.parse(endpoint);
           } catch (ex) {
           }
-          return u.query && u.query.p && (policy.toLowerCase() === u.query.p.toLowerCase());
+          return u.pathname && _.includes(u.pathname, policy.toLowerCase());
         };
         // B2C has no userinfo_endpoint, so no need to check it
         if (!policyChecker(oauthConfig.authorization_endpoint, params.policy)) {


### PR DESCRIPTION
Hi,

Had an issue with policy validation, turns out it is a part of path now:
https://login.microsoftonline.com/te/UUID/b2c_1_elk/oauth2/authorize