### PR TITLE
updated base64url to fix out-of-bounds read vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "base64url": "^2.0.0",
+    "base64url": "^3.0.0",
     "bunyan": "^1.8.0",
     "cache-manager": "^2.0.0",
     "jws": "^3.1.3",


### PR DESCRIPTION
There is a vulnerability in the base64url dependency which unfortunately did not publish a fix as minor or patch update:

```
┌────────────┬────────────────────────────────────────────────────────────────────┐
│             │ Out-of-bounds Read                                                 
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name        │ base64url                                                          
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS        │ 7.1 (High)                                                         
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed   │ 2.0.0                                                              
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable  │ <3.0.0                                                             
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched     │ >=3.0.0                                                            
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path        │ redacted > passport-azure-ad@3.0.12 >              
│             │ base64url@2.0.0                                                    
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info   │ https://nodesecurity.io/advisories/658                             
└────────────┴────────────────────────────────────────────────────────────────────┘
```

see https://nodesecurity.io/advisories/658

This pull requests thus updates base64url to the latest major version to fix this vulnerability.