### PR TITLE
OIDC- fix email retrieval for passport callback

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -81,7 +81,7 @@ function makeProfileObject(src, raw) {
       givenName: src.given_name,
       middleName: src.middle_name,
     },
-    emails: src.emails || [{value: src.email || src.preferred_username }],,
+    emails: src.emails || [{value: src.email || src.preferred_username }],
     _raw: raw,
     _json: src,
   };

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -81,7 +81,7 @@ function makeProfileObject(src, raw) {
       givenName: src.given_name,
       middleName: src.middle_name,
     },
-    emails: src.emails,
+    emails: src.emails || [{value: src.email || src.preferred_username }],,
     _raw: raw,
     _json: src,
   };


### PR DESCRIPTION
Fixes #384

Note: I have no idea if the `src.emails` is actually getting filled for some people?
It hasn't from what I've seen and from the issue above, but I kept it to be safe.