### PR TITLE
get access token using client assertion issue fixed

### DIFF
--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -1415,8 +1415,10 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
  * @params {Object} oauthConfig
  * @params {Function} callback
  */
-Strategy.prototype._getAccessTokenBySecretOrAssertion = (code, oauthConfig, next, callback) => {
+Strategy.prototype._getAccessTokenBySecretOrAssertion = function getAccessTokenBySecretOrAssertion(code, oauthConfig, next, callback) {
   var post_headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+
+  const self = this;
 
   var post_params = {
     code: code,


### PR DESCRIPTION
1. get access token using client assertion issue fixed
2. It will also close this issue => https://github.com/AzureAD/passport-azure-ad/issues/388