### PR TITLE
Add api://clientId to default audience array

### DIFF
--- a/lib/bearerstrategy.js
+++ b/lib/bearerstrategy.js
@@ -217,7 +217,7 @@ function Strategy(options, verifyFn) {
   if (options.audience && typeof options.audience === 'string')
     options.audience = [options.audience];
   else if (!options.audience || !Array.isArray(options.audience) || options.length === 0)
-    options.audience = [options.clientID, 'spn:' + options.clientID];
+    options.audience = [options.clientID, 'spn:' + options.clientID, 'api://' + options.clientID];
 
   // default value of isB2C is false
   if (options.isB2C !== true)


### PR DESCRIPTION
I want to preface this by saying I'm not at all an expert on Azure and/or Azure AD, but I think I've figured out a bug in passport-azure-ad.

What we did was basically follow this guide: https://docs.microsoft.com/en-gb/azure/active-directory/develop/v2-permissions-and-consent which talks about _the Application ID URI_. So let's say our App ID is `123-456-789`, then we requested the token with `scope=offline_access api://123-456-789/user_impersonation`. _Edit:_ After thinking about this some more, the audience is just given in the JWT as `aud`, so it's probably unrelated to the requested scope and just the App's URI.

This is the URI schema (`api://client-id`) that is also displayed in the Portal:

<img width="418" alt="Screenshot 2019-07-23 at 20 33 41" src="https://user-images.githubusercontent.com/432333/61737800-40280480-ad89-11e9-828e-d6da2b9a60fe.png">

But when using `passport-azure-ad`, we get the errors as described in #432 

So while debugging, I found this:

<img width="751" alt="Screenshot 2019-07-23 at 20 03 19" src="https://user-images.githubusercontent.com/432333/61737867-651c7780-ad89-11e9-927e-bb0cd9447fd4.png">

That's why I think, when no explicit audiences are configured for this library, the version with `api://` should also be added.