### PR TITLE
stringify optionsToValidate when logging

### DIFF
--- a/lib/bearerstrategy.js
+++ b/lib/bearerstrategy.js
@@ -487,13 +487,13 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
       if (self._options.scope)
         optionsToValidate.scope = self._options.scope;
 
-      // Beaer token is considered as an access_token.  
+      // Bearer token is considered as an access_token.  
       optionsToValidate.isAccessToken = true;
 
       if (self._options.loggingNoPII)
         log.info(`In Strategy.prototype.authenticate: we will validate the options`);
       else
-        log.info(`In Strategy.prototype.authenticate: we will validate the following options: ${optionsToValidate}`);
+        log.info(`In Strategy.prototype.authenticate: we will validate the following options: ${JSON.stringify(optionsToValidate)}`);
 
       return next();
     }, 


### PR DESCRIPTION
Fixes an issue where the log output contains `[Object object]` instead of the options to validate object.