### PR TITLE
add support for samesite in passport js

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -29,7 +29,7 @@ const util = require('util');
 exports.getLibraryProduct = () => { return 'passport-azure-ad' };
 exports.getLibraryVersionParameterName = () => { return "x-client-Ver" };
 exports.getLibraryProductParameterName = () => { return 'x-client-SKU' };
-exports.getLibraryVersion = () => { 
+exports.getLibraryVersion = () => {
   return '4.0.0';
 };
 
@@ -169,7 +169,7 @@ exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
 exports.checkHashValueRS256 = (content, hashProvided) => {
   if (!content)
     return false;
-  
+
   // step 1. hash the content
   var digest = crypto.createHash('sha256').update(content, 'ascii').digest();
 
@@ -256,7 +256,7 @@ exports.concatUrl = (url, rest) => {
   if (typeof rest === 'string' || rest instanceof String) {
     rest = [rest];
   }
-  
+
   if (!url) {
     return `?${rest.join('&')}`;
   }
@@ -264,4 +264,63 @@ exports.concatUrl = (url, rest) => {
   var hasParam = url.indexOf('?') !== -1;
   return rest ? url.concat(hasParam ? '&' : '?').concat(rest.join('&')) : url;
 };
+
+
+// This is a list maintained by the AAD server team, will need to keep an eye on this
+// as things change.  Not ideal, but it is what it is
+//n general, a change like this (adding a new cookie attribute)
+// should be backward compatible as RFC 6265 specifies that browsers should
+// ignore unknown cookie attributes. However, for the specific case of the
+// SameSite attribute, some browsers incorrectly implemented the attribute or
+//  implemented an earlier draft which had contradictory behavior.
+// For these browsers which attempted to support SameSite,
+// but have bugs in their support, we want to omit the SameSite=None attribute.
+exports.sameSiteNotAllowed = (userAgent) => {
+      // Cover all iOS based browsers here. This includes:
+      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the iOS networking stack
+      if (userAgent.includes("CPU iPhone OS 12") || userAgent.includes("iPad; CPU OS 12"))
+      {
+          return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+      // - Safari on Mac OS X
+      // - Internal browser on Mac OS X
+      // This does not include:
+      // - Chrome on Mac OS X
+      // - Chromium on Mac OS X
+      // Because they do not use the Mac OS networking stack.
+      if (userAgent.includes("Macintosh; Intel Mac OS X 10_14") && !userAgent.includes("Chrome/") && !userAgent.includes("Chromium"))
+      {
+          return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None, and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions, but pre-Chromim Edge does not require SameSite=None, so this is fine.
+      // Note: this regex applies to Windows, Mac OS X, and Linux, deliberately.
+      if (userAgent.includes("Chrome/5") || userAgent.includes("Chrome/6"))
+      {
+          return true;
+      }
+
+      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+      // that don't specify their Chrome version as lacking support for SameSite=None.
+      if (userAgent.includes("UnrealEngine") && !userAgent.includes("Chrome"))
+      {
+          return true;
+      }
+
+      // UCBrowser < 12.13.2 ignores Set-Cookie headers with SameSite=None.
+      // NB: this rule isn't complete - you need regex to make a complete rule.
+      // See: https://www.chromium.org/updates/same-site/incompatible-clients
+      if (userAgent.includes("UCBrowser/12") || userAgent.includes("UCBrowser/11"))
+      {
+          return true;
+      }
+
+      return false;
+}
 

--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -268,13 +268,14 @@ exports.concatUrl = (url, rest) => {
 
 // This is a list maintained by the AAD server team, will need to keep an eye on this
 // as things change.  Not ideal, but it is what it is
-//n general, a change like this (adding a new cookie attribute)
+// in general, a change like this (adding a new cookie attribute)
 // should be backward compatible as RFC 6265 specifies that browsers should
 // ignore unknown cookie attributes. However, for the specific case of the
 // SameSite attribute, some browsers incorrectly implemented the attribute or
 //  implemented an earlier draft which had contradictory behavior.
 // For these browsers which attempted to support SameSite,
 // but have bugs in their support, we want to omit the SameSite=None attribute.
+// See Chromium official guidance here:  https://www.chromium.org/updates/same-site/incompatible-clients
 exports.sameSiteNotAllowed = (userAgent) => {
       // Cover all iOS based browsers here. This includes:
       // - Safari on iOS 12 for iPhone, iPod Touch, iPad

--- a/lib/cookieContentHandler.js
+++ b/lib/cookieContentHandler.js
@@ -25,16 +25,17 @@
 
 var crypto = require('crypto');
 var createBuffer = require('./jwe').createBuffer;
+var sameSiteNotAllowed = require('./aadutils').sameSiteNotAllowed;
 
 /*
  * the handler for state/nonce/policy
  * @maxAmount          - the max amount of {state: x, nonce: x, policy: x} tuples you want to save in cookie
  * @maxAge            - when a tuple in session expires in seconds
- * @cookieEncryptionKeys  
+ * @cookieEncryptionKeys
  *                    - keys used to encrypt and decrypt cookie
  * @domain            - sets the cookie's domain
- */ 
-function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain) {
+ */
+function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain, cookieSameSite) {
   if (!maxAge || (typeof maxAge !== 'number' || maxAge <= 0))
     throw new Error('CookieContentHandler: maxAge must be a positive number');
   this.maxAge = maxAge;  // seconds
@@ -45,6 +46,11 @@ function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain) {
 
   if (!cookieEncryptionKeys || !Array.isArray(cookieEncryptionKeys) || cookieEncryptionKeys.length === 0)
     throw new Error('CookieContentHandler: cookieEncryptionKeys must be a non-emptry array');
+
+  if (typeof cookieSameSite !== 'boolean') {
+    throw new Error('CookieContentHandler: cookieSameSite must be a boolean');
+  }
+  this.cookieSameSite = cookieSameSite
 
   for (var i = 0; i < cookieEncryptionKeys.length; i++) {
     var item = cookieEncryptionKeys[i];
@@ -64,7 +70,7 @@ function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain) {
 CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, stateToFind) {
   if (!req.cookies)
     throw new Error('Cookie is not found in request. Did you forget to use cookie parsing middleware such as cookie-parser?');
-  
+
   var cookieEncryptionKeys = this.cookieEncryptionKeys;
 
   var tuple = null;
@@ -75,7 +81,7 @@ CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, st
     var key = createBuffer(item.key);
     var iv = createBuffer(item.iv);
 
-    for (var cookie in req.cookies) {     
+    for (var cookie in req.cookies) {
       if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.')) {
         var encrypted = cookie.substring(13);
 
@@ -88,7 +94,7 @@ CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, st
 
         if (tuple.state === stateToFind) {
           res.clearCookie(cookie);
-          return tuple;      
+          return tuple;
         }
       }
     }
@@ -101,7 +107,7 @@ CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
   var cookies = [];
 
   // collect the related cookies
-  for (var cookie in req.cookies) {     
+  for (var cookie in req.cookies) {
     if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.'))
       cookies.push(cookie);
   }
@@ -131,6 +137,10 @@ CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
   let options = { maxAge: this.maxAge * 1000, httpOnly: true }
   if (this.domain) {
     options.domain = this.domain;
+  }
+
+  if (this.cookieSameSite && !sameSiteNotAllowed(req.get('User-Agent'))) {
+    options.sameSite = 'none';
   }
 
   res.cookie('passport-aad.' + Date.now() + '.' + encrypted, 0, options);

--- a/lib/cookieContentHandler.js
+++ b/lib/cookieContentHandler.js
@@ -141,6 +141,7 @@ CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
 
   if (this.cookieSameSite && !sameSiteNotAllowed(req.get('User-Agent'))) {
     options.sameSite = 'none';
+    options.secure = true;
   }
 
   res.cookie('passport-aad.' + Date.now() + '.' + encrypted, 0, options);

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -65,7 +65,7 @@ const ttl = 1800; // 30 minutes cache
 //    time is configurable by user.
 // 2. NONCE_MAX_AMOUNT is the max amount of tuples a user's session can have. We limit it to 10.
 //    This value limits the amount of microsoft login page tabs a user can open before the user types
-//    username and password to 10. If the user opens more than 10 login tabs, we only honor the most 
+//    username and password to 10. If the user opens more than 10 login tabs, we only honor the most
 //    recent 10 tabs within the life time.
 const NONCE_MAX_AMOUNT = 10;
 const NONCE_LIFE_TIME = 3600; // second
@@ -131,8 +131,8 @@ function onProfileLoaded(strategy, args) {
  *
  *     function(token, done) { ... }
  * or
- *     function(req, token, done) { .... }  
- *  
+ *     function(req, token, done) { .... }
+ *
  * (passReqToCallback must be set true in options in order to use the second signature.)
  *
  * `token` is the verified and decoded bearer token provided as a credential.
@@ -152,7 +152,7 @@ function onProfileLoaded(strategy, args) {
  *   - `identityMetadata`   (1) Required
  *                          (2) must be a https url string
  *                          (3) Description:
- *                          the metadata endpoint provided by the Microsoft Identity Portal that provides 
+ *                          the metadata endpoint provided by the Microsoft Identity Portal that provides
  *                          the keys and other important info at runtime. Examples:
  *                          <1> v1 tenant-specific endpoint
  *                          - https://login.microsoftonline.com/your_tenant_name.onmicrosoft.com/.well-known/openid-configuration
@@ -189,17 +189,17 @@ function onProfileLoaded(strategy, args) {
  *                          (1) Required to set to true if you want to use http url for redirectUrl
  *                          (2) Description:
  *                          The default value is false. It's OK to use http like 'http://localhost:3000' in the
- *                          dev environment, but in production environment https should always be used. 
+ *                          dev environment, but in production environment https should always be used.
  *
  *   - `clientSecret`       (1) This option only applies when `responseType` is 'code', 'id_token code' or 'code id_token'.
  *                              To redeem an authorization code, we can use either client secret flow or client assertion flow.
  *                              (1.1) For B2C, clientSecret is required since client assertion is not supported
- *                              (1.2) For non-B2C, both flows are supported. Developer must provide either clientSecret, or 
- *                                    thumbprint and privatePEMKey. We use clientSecret if it is provided, otherwise we use 
+ *                              (1.2) For non-B2C, both flows are supported. Developer must provide either clientSecret, or
+ *                                    thumbprint and privatePEMKey. We use clientSecret if it is provided, otherwise we use
  *                                    thumbprint and privatePEMKey for the client assertion flow.
  *                          (2) must be a string
  *                          (3) Description:
- *                          The app key of your app from AAD. 
+ *                          The app key of your app from AAD.
  *                          NOTE: For B2C, the app key sometimes contains '\', please replace '\' with '\\' in the app key, otherwise
  *                          '\' will be treated as the beginning of a escaping character
  *
@@ -233,19 +233,19 @@ function onProfileLoaded(strategy, args) {
  *   - `passReqToCallback`  (1) Required to set true if you want to use the `function(req, token, done)` signature for the verify function, default is false
  *                          (2) Description:
  *                          Set `passReqToCallback` to true use the `function(req, token, done)` signature for the verify function
- *                          Set `passReqToCallback` to false use the `function(token, done)` signature for the verify function 
+ *                          Set `passReqToCallback` to false use the `function(token, done)` signature for the verify function
  *
  *   - `useCookieInsteadOfSession`
  *                          (1) Required to set true if you don't want to use session. Default value is false.
  *                          (2) Description:
- *                          Passport-azure-ad needs to save state and nonce somewhere for validation purpose. If this option is set true, it will encrypt 
+ *                          Passport-azure-ad needs to save state and nonce somewhere for validation purpose. If this option is set true, it will encrypt
  *                          state and nonce and put them into cookie. If this option is false, we save state and nonce in session.
  *
  *   - `cookieEncryptionKeys`
  *                          (1) Required if `useCookieInsteadOfSession` is true.
  *                          (2) Description:
  *                          This must be an array of key items. Each key item has the form { key: '...', iv: '...' }, where key is any string of length 32,
- *                          and iv is any string of length 12. 
+ *                          and iv is any string of length 12.
  *                          We always use the first key item with AES-256-GCM algorithm to encrypt cookie, but we will try every key item when we decrypt
  *                          cookie. This helps when you want to do key roll over.
  *
@@ -258,19 +258,19 @@ function onProfileLoaded(strategy, args) {
  *                          (2) must be a string or an array of strings
  *                          (3) Description:
  *                          list of scope values indicating the required scope of the access token for accessing the requested
- *                          resource. Ex: ['email', 'profile']. 
+ *                          resource. Ex: ['email', 'profile'].
  *                          We send 'openid' by default. For B2C, we also send 'offline_access' (to get refresh_token) and
  *                          clientID (to get access_token) by default.
  *
  *   - `loggingLevel`       (1) Optional
  *                          (2) must be 'info', 'warn', 'error'
- *                          (3) Description:  
- *                          logging level  
+ *                          (3) Description:
+ *                          logging level
  *
  *   - `loggingNoPII`       (1) Optional, default value is true
  *                          (2) Description:
  *                          If this is set to true, no personal information such as tokens and claims will be logged.
- * 
+ *
  *   - `nonceLifetime`      (1) Optional
  *                          (2) must be a positive integer
  *                          (3) Description:
@@ -293,7 +293,7 @@ function onProfileLoaded(strategy, args) {
  *     clientID: config.creds.clientID,
  *     responseType: config.creds.responseType,
  *     responseMode: config.creds.responseMode
- *     redirectUrl: config.creds.redirectUrl, 
+ *     redirectUrl: config.creds.redirectUrl,
  *     allowHttpForRedirectUrl: config.creds.allowHttpForRedirectUrl,
  *     clientSecret: config.creds.clientSecret,
  *     thumbprint: config.creds.thumbprint,
@@ -307,7 +307,8 @@ function onProfileLoaded(strategy, args) {
  *     loggingNoPII: config.creds.loggingNoPII,
  *     nonceLifetime: config.creds.nonceLifetime,
  *     useCookieInsteadOfSession: config.creds.useCookieInsteadOfSession,
- *     cookieEncryptionKeys: config.creds.cookieEncryptionKeys
+ *     cookieEncryptionKeys: config.creds.cookieEncryptionKeys,
+ *     cookieSameSite: boolean
  *   },
  *   function(token, done) {
  *     User.findById(token.sub, function (err, user) {
@@ -332,8 +333,8 @@ function Strategy(options, verify) {
    *  Caution when you want to change these values in the member functions of
    *  Strategy, don't use `this`, since `this` points to a subclass of `Strategy`.
    *  To get `Strategy`, use Object.getPrototypeOf(this).
-   *  
-   *  More comments at the beginning of `Strategy.prototype.authenticate`. 
+   *
+   *  More comments at the beginning of `Strategy.prototype.authenticate`.
    */
   this._options = options;
   this.name = 'azuread-openidconnect';
@@ -349,35 +350,41 @@ function Strategy(options, verify) {
 
   if (!this._useCookieInsteadOfSession) {
     // For each microsoft login page tab, we generate a {state, nonce, policy, timeStamp} tuple,
-    // normally user won't keep opening microsoft login page in new tabs without putting their 
+    // normally user won't keep opening microsoft login page in new tabs without putting their
     // password for more than 10 tabs, so we only keep the most recent 10 tuples in session.
     // The lifetime of each tuple is 60 minutes or user specified.
     this._sessionContentHandler = new SessionContentHandler(options.nonceMaxAmount || NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME);
   } else {
-    this._cookieContentHandler = new CookieContentHandler(options.nonceMaxAmount || NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME, options.cookieEncryptionKeys, options.cookieDomain);
+    this._cookieContentHandler = new CookieContentHandler(
+      options.nonceMaxAmount || NONCE_MAX_AMOUNT,
+      options.nonceLifetime || NONCE_LIFE_TIME,
+      options.cookieEncryptionKeys,
+      options.cookieDomain,
+      !!options.cookieSameSite
+    );
   }
 
   /* When a user is authenticated for the first time, passport adds a new field
    * to req.session called 'passport', and puts a 'user' property inside (or your
-   * choice of field name and property name if you change passport._key and 
-   * passport._userProperty values). req.session['passport']['user'] is usually 
+   * choice of field name and property name if you change passport._key and
+   * passport._userProperty values). req.session['passport']['user'] is usually
    * user_id (or something similar) of the authenticated user to reduce the size
    * of session. When the user logs out, req.session['passport']['user'] will be
    * destroyed. Any request between login (when authenticated for the first time)
    * and logout will have the 'user_id' in req.session['passport']['user'], so
    * passport can fetch it, find the user object in database and put the user
-   * object into a new field: req.user. Then the subsequent middlewares and the 
-   * app can use the user object. This is how passport keeps user authenticated. 
+   * object into a new field: req.user. Then the subsequent middlewares and the
+   * app can use the user object. This is how passport keeps user authenticated.
    *
    * For state validation, we also take advantage of req.session. we create a new
-   * field: req.session[sessionKey], where the sessionKey is our choice (in fact, 
+   * field: req.session[sessionKey], where the sessionKey is our choice (in fact,
    * this._key, see below). When we send a request with state, we put state into
    * req.session[sessionKey].state; when we expect a request with state in query
-   * or body, we compare the state in query/body with the one stored in 
+   * or body, we compare the state in query/body with the one stored in
    * req.session[sessionKey].state, and then destroy req.session[sessionKey].state.
    * User can provide a state by using `authenticate(Strategy, {state: 'xxx'})`, or
    * one will be generated automatically. This is essentially how passport-oauth2
-   * library does the state validation, and we use the same way in our library. 
+   * library does the state validation, and we use the same way in our library.
    *
    * request structure will look like the following. In real request some fields
    * might not be there depending on the purpose of the request.
@@ -385,7 +392,7 @@ function Strategy(options, verify) {
    *    request ---|--- sessionID
    *               |--- session --- |--- ...
    *               |                |--- 'passport' ---| --- 'user': 'user_id etc'
-   *               |                |---  sessionKey---| --- state: 'xxx'            
+   *               |                |---  sessionKey---| --- state: 'xxx'
    *               |--- ...
    *               |--- 'user':  full user info
    */
@@ -401,7 +408,7 @@ function Strategy(options, verify) {
   if (options.loggingLevel) { log.levels('console', options.loggingLevel); }
   this.log = log;
 
-  if (options.loggingNoPII != false) 
+  if (options.loggingNoPII != false)
     options.loggingNoPII = true;
 
   // clock skew. Must be a postive integer
@@ -426,7 +433,7 @@ function Strategy(options, verify) {
   // check if we are using the common endpoint
   options.isCommonEndpoint = (options.identityMetadata.indexOf('/common/') != -1);
 
-  // isB2C is false by default  
+  // isB2C is false by default
   if (options.isB2C !== true)
     options.isB2C = false;
 
@@ -443,10 +450,10 @@ function Strategy(options, verify) {
    * Take care of issuer and audience
    * (1) We use user provided `issuer`, and the issuer value from metadata if the metadata
    *     comes from tenant-specific endpoint (in other words, either the identityMetadata
-   *     is tenant-specific, or it is common but you provide tenantIdOrName in 
-   *     passport.authenticate). 
+   *     is tenant-specific, or it is common but you provide tenantIdOrName in
+   *     passport.authenticate).
    *
-   *     For common endpoint, if `issuer` is not provided by user, and `tenantIdOrName` is 
+   *     For common endpoint, if `issuer` is not provided by user, and `tenantIdOrName` is
    *     not used in passport.authenticate, then we don't know the issuer, and `validateIssuer`
    *     must be set to false
    * (2) `validateIssuer` is true by default. we validate issuer unless validateIssuer is set false
@@ -493,7 +500,7 @@ function Strategy(options, verify) {
     options.responseType = 'code id_token';
 
   var itemsToValidate = {};
-  aadutils.copyObjectFields(options, itemsToValidate, ['clientID', 'redirectUrl', 'responseType', 'responseMode', 'identityMetadata']); 
+  aadutils.copyObjectFields(options, itemsToValidate, ['clientID', 'redirectUrl', 'responseType', 'responseMode', 'identityMetadata']);
 
   var validatorConfiguration = {
     clientID: Validator.isNonEmpty,
@@ -501,7 +508,7 @@ function Strategy(options, verify) {
     responseMode: Validator.isModeLegal,
     identityMetadata: Validator.isHttpsURL
   };
-  
+
   // redirectUrl is https by default
   if (options.allowHttpForRedirectUrl === true)
     validatorConfiguration.redirectUrl = Validator.isURL;
@@ -543,23 +550,23 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
-  /* 
+  /*
    * We should be careful using 'this'. Avoid the usage like `this.xxx = ...`
    * unless you know what you are doing.
    *
-   * In the passport source code 
+   * In the passport source code
    * (https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js)
    * when it attempts to call the `oidcstrategy.authenticate` function, passport
-   * creates an instance inherting oidcstrategy and then calls `instance.authenticate`.  
+   * creates an instance inherting oidcstrategy and then calls `instance.authenticate`.
    * Therefore, when we come here, `this` is the instance, its prototype is the
    * actual oidcstrategy, i.e. the `Strategy`. This means:
    * (1) `this._options = `, `this._verify = `, etc only adds new fields to the
-   *      instance, it doesn't change the values in oidcstrategy, i.e. `Strategy`. 
+   *      instance, it doesn't change the values in oidcstrategy, i.e. `Strategy`.
    * (2) `this._options`, `this._verify`, etc returns the field in the instance,
    *     and if there is none, returns the field in oidcstrategy, i.e. `strategy`.
    * (3) each time we call `authenticate`, we will get a brand new instance
-   * 
-   * If you want to change the values in `Strategy`, use 
+   *
+   * If you want to change the values in `Strategy`, use
    *      const oidcstrategy = Object.getPrototypeOf(self);
    * to get the strategy first.
    *
@@ -580,7 +587,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
    *                 | --  __proto__:
    *                              | --  authenticate:  function(req, options)
    *                              | --  ...
-   */ 
+   */
   const self = this;
 
   var resource = options && options.resourceURL;
@@ -594,11 +601,11 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   var response = options && options.response || req.res;
 
   // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
-  var params = { 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams }; 
+  var params = { 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams };
   // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
   var oauthConfig = { 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt, 'response': response };
-  // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc  
-  var optionsToValidate = {}; 
+  // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc
+  var optionsToValidate = {};
 
   async.waterfall(
     [
@@ -617,7 +624,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
         return self.setOptions(params, oauthConfig, optionsToValidate, next);
       },
 
-      /***************************************************************************** 
+      /*****************************************************************************
        * Step 3. Handle the flows
        *----------------------------------------------------------------------------
        * (1) implicit flow (response_type = 'id_token')
@@ -626,8 +633,8 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
        *     This case we get both 'id_token' and 'code'
        * (3) authorization code flow (response_type = 'code')
        *     This case we get a 'code', we will use it to get 'access_token' and 'id_token'
-       * (4) for any other request, we will ask for authorization and initialize 
-       *     the authorization process 
+       * (4) for any other request, we will ask for authorization and initialize
+       *     the authorization process
        ****************************************************************************/
       (next) => {
         if (params.err) {
@@ -661,8 +668,8 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 /**
  * Collect information from the request, for instance, code, err, id_token etc
  *
- * @param {Object} params 
- * @param {Object} req    
+ * @param {Object} params
+ * @param {Object} req
  * @param {Object} next
  */
 Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
@@ -695,7 +702,7 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
     params.code = source.code;
     params.state = source.state;
     if (source.state && source.state.length >= 38) {
-      // the random generated state always has 32 characters. This state is longer than 32 
+      // the random generated state always has 32 characters. This state is longer than 32
       // so it must be a custom state. We added 'CUSTOM' prefix and a random 32 byte long
       // string in front of the original custom state, now we change it back.
       if (!source.state.startsWith('CUSTOM'))
@@ -708,7 +715,7 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
   // -------------------------------------------------------------------------
   // If we received code, id_token or err, we must have received state, now we
   // find the state/nonce/policy tuple from session.
-  // If we received none of them, find policy in query       
+  // If we received none of them, find policy in query
   // -------------------------------------------------------------------------
   if (params.id_token || params.code || params.err) {
     if (!params.state)
@@ -734,7 +741,7 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
         log.info('user provided tenantIdOrName is ignored for redirectUrl, we will use the one stored in session');
       else
         log.info(`user provided tenantIdOrName '${params.tenantIdOrName}' is ignored for redirectUrl, we will use the one stored in session`);
-    }      
+    }
     params.tenantIdOrName = tuple['tenantIdOrName'];
   } else {
     params.policy = req.query.p ? req.query.p.toLowerCase() : null;
@@ -749,7 +756,7 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
     params.tenantIdOrName = null;
   }
 
-  // if we are using the common endpoint and we want to validate issuer, then user has to 
+  // if we are using the common endpoint and we want to validate issuer, then user has to
   // provide issuer in config, or provide tenant id or name using tenantIdOrName option in
   // passport.authenticate. Otherwise we won't know the issuer.
   if (self._options.isCommonEndpoint && self._options.validateIssuer &&
@@ -764,10 +771,10 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
     return next(new Error('In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided'));
 
   // -------------------------------------------------------------------------
-  // calculate metadataUrl, create a cachekey and an Metadata object instance  
-  // we will fetch the metadata, save it into the object using the cachekey       
-  // -------------------------------------------------------------------------   
-  var metadataUrl = self._options.identityMetadata;   
+  // calculate metadataUrl, create a cachekey and an Metadata object instance
+  // we will fetch the metadata, save it into the object using the cachekey
+  // -------------------------------------------------------------------------
+  var metadataUrl = self._options.identityMetadata;
 
   // if we are using common endpoint and we are given the tenantIdOrName, let's replace it
   if (self._options.isCommonEndpoint && params.tenantIdOrName) {
@@ -800,7 +807,7 @@ Strategy.prototype.collectInfoFromReq = function(params, req, next, response) {
  * @param {Object} params             -- parameters we get from the request
  * @param {Object} oauthConfig        -- the items we need for oauth flow
  * @param {Object} optionsToValidate  -- the items we need to validate id_token
- * @param {Function} done             -- the callback 
+ * @param {Function} done             -- the callback
  */
 Strategy.prototype.setOptions = function setOptions(params, oauthConfig, optionsToValidate, done) {
   const self = this;
@@ -813,7 +820,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       memoryCache.wrap(params.cachekey, (cacheCallback) => {
         params.metadata.fetch((fetchMetadataError) => {
           if (fetchMetadataError) {
-            return cacheCallback(fetchMetadataError); 
+            return cacheCallback(fetchMetadataError);
           }
           return cacheCallback(null, params.metadata);
         });
@@ -827,7 +834,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       if (!metadata.oidc)
         return next(new Error('In setOptions: failed to load metadata'));
       params.metadata = metadata;
-      
+
       // copy the fields needed into 'oauthConfig'
       aadutils.copyObjectFields(metadata.oidc, oauthConfig, ['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint']);
       aadutils.copyObjectFields(self._options, oauthConfig, ['clientID', 'clientSecret', 'privatePEMKey', 'thumbprint', 'responseType', 'responseMode', 'scope', 'redirectUrl']);
@@ -853,7 +860,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       // for B2C, verify the endpoints in oauthConfig has the correct policy
       if (self._options.isB2C){
         var policyChecker = (endpoint, policy) => {
-          var u = {};          
+          var u = {};
           try {
             u = url.parse(endpoint);
           } catch (ex) {
@@ -866,13 +873,13 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
             return next(new Error('invalid policy'));
           else
             return next(new Error(`policy in ${oauthConfig.authorization_endpoint} should be ${params.policy}`));
-        }        
+        }
         if (!policyChecker(oauthConfig.token_endpoint, params.policy)) {
           if (self._options.loggingNoPII)
             return next(new Error('invalid policy'));
           else
             return next(new Error(`policy in ${oauthConfig.token_endpoint} should be ${params.policy}`));
-        }         
+        }
       }
 
       return next(null, metadata);
@@ -888,7 +895,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
         return next(null);
 
       // set items from self._options
-      aadutils.copyObjectFields(self._options, optionsToValidate, 
+      aadutils.copyObjectFields(self._options, optionsToValidate,
         ['validateIssuer', 'audience', 'allowMultiAudiencesInToken', 'ignoreExpiration', 'allowMultiAudiencesInToken']);
 
       // algorithms
@@ -1040,7 +1047,7 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
     // check c_hash
     if (jwtClaims.c_hash) {
       // checkHashValueRS256 checks if code is null, so we don't bother here
-      if (!aadutils.checkHashValueRS256(code, jwtClaims.c_hash)) 
+      if (!aadutils.checkHashValueRS256(code, jwtClaims.c_hash))
         return next(new Error("In _validateResponse: invalid c_hash"));
     }
 
@@ -1061,7 +1068,7 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
 /**
  * handle error response
  *
- * @params {String} err 
+ * @params {String} err
  * @params {String} err_description
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
@@ -1072,9 +1079,9 @@ Strategy.prototype._errorResponseHandler = function errorResponseHandler(err, er
   if (err_description && !self._options.loggingNoPII)
     log.info('Error description received in the response was: ', err_description);
 
-  // Unfortunately, we cannot return the 'error description' to the user, since 
+  // Unfortunately, we cannot return the 'error description' to the user, since
   // it goes to http header by default and it usually contains characters that
-  // http header doesn't like, which causes the program to crash. 
+  // http header doesn't like, which causes the program to crash.
   return next(new Error(err));
 };
 
@@ -1082,7 +1089,7 @@ Strategy.prototype._errorResponseHandler = function errorResponseHandler(err, er
  * handle the response where we only get 'id_token' in the response
  *
  * @params {Object} params
- * @params {Object} optionsToValidate 
+ * @params {Object} optionsToValidate
  * @params {Object} req
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
@@ -1124,14 +1131,14 @@ Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(params, o
  *
  * @params {Object} params
  * @params {Object} oauthConfig
- * @params {Object} optionsToValidate 
+ * @params {Object} optionsToValidate
  * @params {Object} req
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
 Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauthConfig, optionsToValidate, req, next) {
   /* we will do the following things in order
    * (1) validate the id_token and the code
-   * (2) if there is no userinfo token needed (or ignored if using AAD v2 ), we use 
+   * (2) if there is no userinfo token needed (or ignored if using AAD v2 ), we use
    *     the claims in id_token for user's profile
    * (3) if userinfo token is needed, we will use the 'code' and the authorization code flow
    */
@@ -1142,7 +1149,7 @@ Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauth
   else
     log.info('entering Strategy.prototype._hybridFlowHandler, received code: ' + params.code + ', received id_token: ' + params.id_token);
 
-  // save nonce, since if we use the authorization code flow later, we have to check 
+  // save nonce, since if we use the authorization code flow later, we have to check
   // nonce again.
 
   // validate the id_token and the code
@@ -1165,13 +1172,13 @@ Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauth
  *
  * @params {Object} params
  * @params {Object} oauthConfig
- * @params {Object} optionsToValidate 
+ * @params {Object} optionsToValidate
  * @params {Object} req
  * @params {Function} next  -- callback to pass error to async.waterfall
- * // the following are required if you used 'code id_token' flow then call this function to 
- * // redeem the code for another id_token from the token endpoint. iss and sub are those 
+ * // the following are required if you used 'code id_token' flow then call this function to
+ * // redeem the code for another id_token from the token endpoint. iss and sub are those
  * // in the id_token from authorization endpoint, and they should match those in the id_token
- * // from the token endpoint 
+ * // from the token endpoint
  * @params {String} iss
  * @params {String} sub
  */
@@ -1200,24 +1207,24 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
       else
         return next(new Error(`In _authCodeFlowHandler: failed to redeem authorization code: ${aadutils.getErrorMessage(getOAuthAccessTokenError)}`));
     }
-    
+
     var access_token = items.access_token;
     var refresh_token = items.refresh_token;
 
     // id_token should be present
     if (!items.id_token)
       return next(new Error('In _authCodeFlowHandler: id_token is not received'));
-    
+
     // if we get access token, we must have token_type as well
     if (items.access_token && !items.token_type)
       return next(new Error('In _authCodeFlowHandler: token_type is missing'));
-    
+
     // token_type must be 'Bearer' ignoring the case
     if (items.token_type && items.token_type.toLowerCase() !== 'bearer') {
       log.info('token_type received is: ', items.token_type);
       return next(new Error(`In _authCodeFlowHandler: token_type received is not 'Bearer' ignoring the case`));
     }
-    
+
     if (!self._options.loggingNoPII) {
       log.info('received id_token: ', items.id_token);
       log.info('received access_token: ', access_token);
@@ -1238,9 +1245,9 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
 
       const sub = jwtClaims.sub;
       const iss = jwtClaims.iss;
-      
+
       // load the userinfo, if this is not v2 and if we don't specify the resource
-      // for v1 if we don't specify the resource, then the access_token we got is for userinfo endpoint, so we can use it to get userinfo 
+      // for v1 if we don't specify the resource, then the access_token we got is for userinfo endpoint, so we can use it to get userinfo
       if (!self._options._isV2 && !params.resource) {
         // make sure we get an access_token
         if (!access_token)
@@ -1269,7 +1276,7 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
               return next(new Error('In _authCodeFlowHandler: failed to fetch user profile'));
             else
               return next(new Error(`In _authCodeFlowHandler: failed to fetch user profile: ${aadutils.getErrorMessage(getUserInfoError)}`));
-          }           
+          }
 
           if (self._options.loggingNoPII)
             log.info('Profile is loaded from MS identity');
@@ -1374,7 +1381,7 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
         return next(new Error('In _flowInitializationHandler: the given policy in the request is invalid'));
       else
         return next(new Error(`In _flowInitializationHandler: the given policy ${policy} given in the request is invalid`));
-    }      
+    }
   }
 
   // add state/nonce/policy/timeStamp tuple to session or cookie
@@ -1400,14 +1407,14 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
     // expiration when we set cookie
     self._cookieContentHandler.add(req, oauthConfig.response, tuple);
   }
-  
+
   // add scope
   params.scope = oauthConfig.scope;
 
   // add telemetry
   params[aadutils.getLibraryProductParameterName()] = aadutils.getLibraryProduct();
   params[aadutils.getLibraryVersionParameterName()] = aadutils.getLibraryVersion();
-  
+
   const location = aadutils.concatUrl(oauthConfig.authorization_endpoint, querystring.stringify(params));
 
   return self.redirect(location);
@@ -1447,7 +1454,7 @@ Strategy.prototype._getAccessTokenBySecretOrAssertion = function getAccessTokenB
     log.info('In _getAccessTokenBySecretOrAssertion: we are using client secret');
   } else {
     // otherwise generate a client assertion
-    post_params['client_assertion_type'] = CONSTANTS.CLIENT_ASSERTION_TYPE;   
+    post_params['client_assertion_type'] = CONSTANTS.CLIENT_ASSERTION_TYPE;
 
     jwt.generateClientAssertion(oauthConfig.clientID, oauthConfig.token_endpoint, oauthConfig.privatePEMKey, oauthConfig.thumbprint,
       (err, assertion) => {
@@ -1478,7 +1485,7 @@ Strategy.prototype._getAccessTokenBySecretOrAssertion = function getAccessTokenB
       }
       callback(null, results);
     }
-  });   
+  });
 };
 
 /**


### PR DESCRIPTION
To avoid breaking consumers who are using an http framework where this is not supported, I have added an opt in `cookieSameSite` option to OIDC config.
This will be a minor release. 