### PR TITLE
Strip nonbreaking spaces and fix a few lint errors

### DIFF
--- a/lib/aadutils.js
+++ b/lib/aadutils.js
@@ -276,52 +276,46 @@ exports.concatUrl = (url, rest) => {
 // For these browsers which attempted to support SameSite,
 // but have bugs in their support, we want to omit the SameSite=None attribute.
 // See Chromium official guidance here:  https://www.chromium.org/updates/same-site/incompatible-clients
-exports.sameSiteNotAllowed = (userAgent) => {
-      // Cover all iOS based browsers here. This includes:
-      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
-      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
-      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
-      // All of which are broken by SameSite=None, because they use the iOS networking stack
-      if (userAgent.includes("CPU iPhone OS 12") || userAgent.includes("iPad; CPU OS 12"))
-      {
-          return true;
-      }
+exports.sameSiteNotAllowed = userAgent => {
+  // Cover all iOS based browsers here. This includes:
+  // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+  // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+  // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+  // All of which are broken by SameSite=None, because they use the iOS networking stack
+  if (userAgent.includes("CPU iPhone OS 12") || userAgent.includes("iPad; CPU OS 12")) {
+    return true;
+  }
 
-      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
-      // - Safari on Mac OS X
-      // - Internal browser on Mac OS X
-      // This does not include:
-      // - Chrome on Mac OS X
-      // - Chromium on Mac OS X
-      // Because they do not use the Mac OS networking stack.
-      if (userAgent.includes("Macintosh; Intel Mac OS X 10_14") && !userAgent.includes("Chrome/") && !userAgent.includes("Chromium"))
-      {
-          return true;
-      }
+  // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+  // - Safari on Mac OS X
+  // - Internal browser on Mac OS X
+  // This does not include:
+  // - Chrome on Mac OS X
+  // - Chromium on Mac OS X
+  // Because they do not use the Mac OS networking stack.
+  if (userAgent.includes("Macintosh; Intel Mac OS X 10_14") && !userAgent.includes("Chrome/") && !userAgent.includes("Chromium")) {
+    return true;
+  }
 
-      // Cover Chrome 50-69, because some versions are broken by SameSite=None, and none in this range require it.
-      // Note: this covers some pre-Chromium Edge versions, but pre-Chromim Edge does not require SameSite=None, so this is fine.
-      // Note: this regex applies to Windows, Mac OS X, and Linux, deliberately.
-      if (userAgent.includes("Chrome/5") || userAgent.includes("Chrome/6"))
-      {
-          return true;
-      }
+  // Cover Chrome 50-69, because some versions are broken by SameSite=None, and none in this range require it.
+  // Note: this covers some pre-Chromium Edge versions, but pre-Chromim Edge does not require SameSite=None, so this is fine.
+  // Note: this regex applies to Windows, Mac OS X, and Linux, deliberately.
+  if (userAgent.includes("Chrome/5") || userAgent.includes("Chrome/6")) {
+    return true;
+  }
 
-      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
-      // that don't specify their Chrome version as lacking support for SameSite=None.
-      if (userAgent.includes("UnrealEngine") && !userAgent.includes("Chrome"))
-      {
-          return true;
-      }
+  // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+  // that don't specify their Chrome version as lacking support for SameSite=None.
+  if (userAgent.includes("UnrealEngine") && !userAgent.includes("Chrome")) {
+    return true;
+  }
 
-      // UCBrowser < 12.13.2 ignores Set-Cookie headers with SameSite=None.
-      // NB: this rule isn't complete - you need regex to make a complete rule.
-      // See: https://www.chromium.org/updates/same-site/incompatible-clients
-      if (userAgent.includes("UCBrowser/12") || userAgent.includes("UCBrowser/11"))
-      {
-          return true;
-      }
+  // UCBrowser < 12.13.2 ignores Set-Cookie headers with SameSite=None.
+  // NB: this rule isn't complete - you need regex to make a complete rule.
+  // See: https://www.chromium.org/updates/same-site/incompatible-clients
+  if (userAgent.includes("UCBrowser/12") || userAgent.includes("UCBrowser/11")) {
+    return true;
+  }
 
-      return false;
-}
-
+  return false;
+};

--- a/test/Chai-passport_test/cookie_test.js
+++ b/test/Chai-passport_test/cookie_test.js
@@ -235,7 +235,7 @@ describe('cookie test', function() {
     var handler1 = new CookieContentHandler(2, 10, [ { key: '4zTvzr3p56VC61jmV54rIYu1545x4TlY', iv: '70iP0h6vPoEa' } ], null, true);
 
     // clear request
-    req = { get: () => 'iPad; CPU OS 12' };
+    req = { get: () => 'iPad; CPU OS 12' };
 
     // set cookie using handler1
     handler1.add(req, res, { state: '1', nonce: 'some nonce' });


### PR DESCRIPTION
Fixes #464 based on a cursory test of a single sample userAgent:

```
const util = require('util');
const assert = require('assert').strict;

const { sameSiteNotAllowed } = require('./node_modules/passport-azure-ad/lib/aadutils.js');

const userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/21.0 Mobile/15E148 Safari/605.1.15";
try {
  assert.equal(
    sameSiteNotAllowed(userAgent),
    true
  );
  console.log(`${util.inspect(sameSiteNotAllowed)} returned true`);
} catch (err) {
  console.log(err);
}

const fixed = require('./aadutils.js').sameSiteNotAllowed;

try {
  assert.equal(
    fixed(userAgent),
    true
  );
  console.log(`${util.inspect(fixed)} returned true`);
} catch (err) {
  console.log(err);
}
```