### PR TITLE
pin version of cache-manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "async": "^1.5.2",
     "base64url": "^3.0.0",
     "bunyan": "^1.8.0",
-    "cache-manager": "^2.0.0",
+    "cache-manager": "2.10.2",
     "jws": "^3.1.3",
     "jwk-to-pem": "^1.2.6",
     "lodash": "^4.11.2",


### PR DESCRIPTION
The dependency `cache-manager` changed from using `lodash.clonedeep` in `2.10.2` to `deepmerge` in `2.11.0`, this appears to have introduced some breaking changes around the `generateOidcPEM` method.

The simplest fix for this is to pin the version of `cache-manager` to `2.10.2`

This resolves #469

