### PR TITLE
fixing the SO tag here.

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ Azure Identity samples for this plug-in can be found in the following links:
 
 We leverage [Stack Overflow](http://stackoverflow.com/) to work with the community on supporting Azure Active Directory and its SDKs, including this one. We highly recommend you ask your questions on Stack Overflow (we're all on there!) Also browser existing issues to see if someone has had your question before. 
 
-We recommend you use the "adal" tag so we can see it! Here is the latest Q&A on Stack Overflow for ADAL: [http://stackoverflow.com/questions/tagged/adal](http://stackoverflow.com/questions/tagged/adal)
+We recommend you use the "msal" tag so we can see it! Here is the latest Q&A on Stack Overflow for MSAL: [http://stackoverflow.com/questions/tagged/msal](http://stackoverflow.com/questions/tagged/msal)
 
 ## 10. Security Reporting
 


### PR DESCRIPTION
MSAL was not really a product when passport.js was created, so made sense to have ADAL at that point as the SO tag. but we now should be using MSAL. Updating here so customers get answers faster.