### PR TITLE
README: recommend regenerating session by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ passport.use(new OIDCStrategy({
 
 * `useCookieInsteadOfSession`  (Conditional)
   
-  Passport-azure-ad saves state and nonce in session by default for validation purpose. If `useCookieInsteadOfSession` is set to true, passport-azure-ad will encrypt the state/nonce and
-  put them into cookie instead. This is helpful when we want to be completely session-free, in other words, when you use { session: false } option in passport.authenticate function.
+  Passport-azure-ad saves state and nonce in session by default for validation purpose. Consider regenerating the session
+  after authentication to prevent session fixation attacks when using the default. If `useCookieInsteadOfSession` is set to 
+  true, passport-azure-ad will encrypt the state/nonce and put them into cookie instead. This is helpful when we want to be 
+  completely session-free, in other words, when you use { session: false } option in passport.authenticate function.
   If `useCookieInsteadOfSession` is set to true, you must provide `cookieEncryptionKeys` for cookie encryption and decryption.
 
 * `cookieEncryptionKeys`  (Conditional)
@@ -341,6 +343,17 @@ app.get('/login',
     res.redirect('/');
 });
 
+function regenerateSessionAfterAuthentication(req, res, next) {
+  var passportInstance = req.session.passport;
+  return req.session.regenerate(function (err){
+    if (err) {
+      return next(err);
+    }
+    req.session.passport = passportInstance;
+    return req.session.save(next);
+  });
+}
+
 // POST /auth/openid/return
 //   Use passport.authenticate() as route middleware to authenticate the
 //   request.  If authentication fails, the user will be redirected back to the
@@ -348,6 +361,7 @@ app.get('/login',
 //   which, in this example, will redirect the user to the home page.
 app.post('/auth/openid/return',
   passport.authenticate('azuread-openidconnect', { failureRedirect: '/' }),
+  regenerateSessionAfterAuthentication,
   function(req, res) { 
     res.redirect('/');
   });


### PR DESCRIPTION
The Passport library by default does not prevent against session fixation. Since
the default experience for `passport-azure-ad` is to use cookies, I thought it
would be helpful for the README example to clearly regenerate the session.

This is not a vulnerability with the library itself, but rather just extra caution
common to the passport ecosystem per https://github.com/jaredhanson/passport/issues/192.