### PR TITLE
Add option to force verify callback signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ passport.use(new OIDCStrategy({
 * `clockSkew`  (Optional)
 
   This value is the clock skew (in seconds) allowed in token validation. It must be a positive integer. The default value is 300 seconds.
+
+* `verifyArity`  (Optional)
+
+  This value forces the signature of the verify callback (see Sec. 4.1.1.3). It must be a positive integer between 2 and 8. The default behavior is to automatically detect the arity (number of arguments) of the verify callback.
   
 ##### 4.1.1.3 Verify callback
 
@@ -237,6 +241,8 @@ If you set `passReqToCallback` option to true, you can use one of the following 
   function(req, iss, sub, done)
   function(req, profile, done)
 ```
+
+The signature of the verify callback can be forced via the option `verifyArity`, for example `verifyArity = 8` forces the first signature. Valid values for `verifyArity` are, respectively, `8`, `7`, `6`, `4`, `3`, `2`.
 
 #### 4.1.1.4 JWE support
 

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -107,7 +107,7 @@ function onProfileLoaded(strategy, args) {
     3: 'iss sub',
   };
 
-  const arity = (strategy._passReqToCallback) ? strategy._verify.length - 1 : strategy._verify.length;
+  const arity = strategy._verifyArity;
   let verifyArgs = [args.profile, verified];
 
   if (verifyArityArgsMap[arity]) {
@@ -347,6 +347,11 @@ function Strategy(options, verify) {
   // stuff related to the verify function
   this._verify = verify;
   this._passReqToCallback = !!options.passReqToCallback;
+  if (options.verifyArity && (typeof options.verifyArity !== 'number' || options.verifyArity <= 0 || options.verifyArity % 1 !== 0)) {
+    this._verifyArity = (this._passReqToCallback) ? this._verify.length - 1 : this._verify.length
+  } else {
+    this._verifyArity = options.verifyArity
+  }
 
   if (options.useCookieInsteadOfSession === true)
     this._useCookieInsteadOfSession = true;

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -341,7 +341,6 @@ function Strategy(options, verify) {
    *
    *  More comments at the beginning of `Strategy.prototype.authenticate`.
    */
-  this._options = options;
   this.name = 'azuread-openidconnect';
 
   // stuff related to the verify function
@@ -352,6 +351,16 @@ function Strategy(options, verify) {
   } else {
     this._verifyArity = options.verifyArity
   }
+
+  this._setInitialOptions(options);
+}
+
+// Inherit from `passport.Strategy`.
+util.inherits(Strategy, passport.Strategy);
+
+
+Strategy.prototype._setInitialOptions = function setInitialOptions(options) {
+  this._options = options;
 
   if (options.useCookieInsteadOfSession === true)
     this._useCookieInsteadOfSession = true;
@@ -549,9 +558,6 @@ function Strategy(options, verify) {
     log.warn(`Using http for redirectUrl is not recommended, please consider using https`);
 }
 
-// Inherit from `passport.Strategy`.
-util.inherits(Strategy, passport.Strategy);
-
 /**
  * Authenticate request by delegating to an OpenID Connect provider.
  *
@@ -610,15 +616,28 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   var extraTokenReqQueryParams = options && options.extraTokenReqQueryParams;
   var response = options && options.response || req.res;
 
-  // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
-  var params = { 'proxy': self._options.proxy, 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams };
-  // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
-  var oauthConfig = { 'proxy': self._options.proxy, 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt, 'response': response };
-  // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc
-  var optionsToValidate = {};
+  var params, oauthConfig, optionsToValidate;
 
   async.waterfall(
     [
+      async (next) => {
+        if (this._options.optionsFromRequest) {
+          const optionsFromRequest = this._options.optionsFromRequest.bind(self)
+          const options = await optionsFromRequest()
+          self._setInitialOptions(options);
+        }
+        tenantIdOrName = self._options.tenantIdOrName;
+
+        // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
+        params = { 'proxy': self._options.proxy, 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams };
+        // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
+        oauthConfig = { 'proxy': self._options.proxy, 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt, 'response': response };
+        // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc
+        optionsToValidate = {};
+
+        return next();
+      },
+
       /*****************************************************************************
        * Step 1. Collect information from the req and save the info into params
        ****************************************************************************/

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -622,8 +622,8 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
     [
       async (next) => {
         if (this._options.optionsFromRequest) {
-          const optionsFromRequest = this._options.optionsFromRequest.bind(self)
-          const options = await optionsFromRequest()
+          const optionsFromRequest = this._options.optionsFromRequest.bind(self);
+          const options = await optionsFromRequest(req);
           self._setInitialOptions(options);
         }
         tenantIdOrName = self._options.tenantIdOrName;


### PR DESCRIPTION
There are situation where the signature of the verify callback isn't correctly auto-detected. This PR adds an option to force the desired signature.

One relevant example is the NestJS framework, see [this issue](https://github.com/nestjs/passport/issues/53) caused by [this code](https://github.com/nestjs/passport/blob/master/lib/passport/passport.strategy.ts#L17).
